### PR TITLE
Requests redisign part 0

### DIFF
--- a/src/bot/download.rs
+++ b/src/bot/download.rs
@@ -20,7 +20,7 @@ impl Bot {
     /// use teloxide_core::types::File as TgFile;
     /// use tokio::fs::File;
     /// # use teloxide_core::RequestError;
-    /// use teloxide_core::{requests::Request, Bot};
+    /// use teloxide_core::{requests::RequestOld, Bot};
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let bot = Bot::new("TOKEN");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 // ```console
 // $ RUSTDOCFLAGS="--cfg docsrs" cargo doc --open --all-features
 // ```
-#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg))]
+#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg, doc_spotlight))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 #![forbid(unsafe_code)]
 //#![deny(missing_docs)]
 

--- a/src/requests/all/add_sticker_to_set.rs
+++ b/src/requests/all/add_sticker_to_set.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use crate::{
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::StickerType,
 };
 
@@ -28,7 +28,7 @@ pub struct AddStickerToSet {
 }
 
 #[async_trait::async_trait]
-impl Request for AddStickerToSet {
+impl RequestOld for AddStickerToSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/answer_callback_query.rs
+++ b/src/requests/all/answer_callback_query.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::True,
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct AnswerCallbackQuery {
 }
 
 #[async_trait::async_trait]
-impl Request for AnswerCallbackQuery {
+impl RequestOld for AnswerCallbackQuery {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/answer_inline_query.rs
+++ b/src/requests/all/answer_inline_query.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineQueryResult, True},
     Bot,
 };
@@ -27,7 +27,7 @@ pub struct AnswerInlineQuery {
 }
 
 #[async_trait::async_trait]
-impl Request for AnswerInlineQuery {
+impl RequestOld for AnswerInlineQuery {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/answer_pre_checkout_query.rs
+++ b/src/requests/all/answer_pre_checkout_query.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::True,
     Bot,
 };
@@ -30,7 +30,7 @@ pub struct AnswerPreCheckoutQuery {
 }
 
 #[async_trait::async_trait]
-impl Request for AnswerPreCheckoutQuery {
+impl RequestOld for AnswerPreCheckoutQuery {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/answer_shipping_query.rs
+++ b/src/requests/all/answer_shipping_query.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ShippingOption, True},
     Bot,
 };
@@ -27,7 +27,7 @@ pub struct AnswerShippingQuery {
 }
 
 #[async_trait::async_trait]
-impl Request for AnswerShippingQuery {
+impl RequestOld for AnswerShippingQuery {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/create_new_sticker_set.rs
+++ b/src/requests/all/create_new_sticker_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{MaskPosition, StickerType, True},
     Bot,
 };
@@ -27,7 +27,7 @@ pub struct CreateNewStickerSet {
 }
 
 #[async_trait::async_trait]
-impl Request for CreateNewStickerSet {
+impl RequestOld for CreateNewStickerSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/delete_chat_photo.rs
+++ b/src/requests/all/delete_chat_photo.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct DeleteChatPhoto {
 }
 
 #[async_trait::async_trait]
-impl Request for DeleteChatPhoto {
+impl RequestOld for DeleteChatPhoto {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/delete_chat_sticker_set.rs
+++ b/src/requests/all/delete_chat_sticker_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -26,7 +26,7 @@ pub struct DeleteChatStickerSet {
 }
 
 #[async_trait::async_trait]
-impl Request for DeleteChatStickerSet {
+impl RequestOld for DeleteChatStickerSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/delete_message.rs
+++ b/src/requests/all/delete_message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -32,7 +32,7 @@ pub struct DeleteMessage {
 }
 
 #[async_trait::async_trait]
-impl Request for DeleteMessage {
+impl RequestOld for DeleteMessage {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/delete_sticker_from_set.rs
+++ b/src/requests/all/delete_sticker_from_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::True,
     Bot,
 };
@@ -19,7 +19,7 @@ pub struct DeleteStickerFromSet {
 }
 
 #[async_trait::async_trait]
-impl Request for DeleteStickerFromSet {
+impl RequestOld for DeleteStickerFromSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/delete_webhook.rs
+++ b/src/requests/all/delete_webhook.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::True,
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct DeleteWebhook {
 }
 
 #[async_trait::async_trait]
-impl Request for DeleteWebhook {
+impl RequestOld for DeleteWebhook {
     type Output = True;
 
     #[allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/requests/all/edit_inline_message_caption.rs
+++ b/src/requests/all/edit_inline_message_caption.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, ParseMode, True},
     Bot,
 };
@@ -26,7 +26,7 @@ pub struct EditInlineMessageCaption {
 }
 
 #[async_trait::async_trait]
-impl Request for EditInlineMessageCaption {
+impl RequestOld for EditInlineMessageCaption {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/edit_inline_message_live_location.rs
+++ b/src/requests/all/edit_inline_message_live_location.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, True},
     Bot,
 };
@@ -28,7 +28,7 @@ pub struct EditInlineMessageLiveLocation {
 }
 
 #[async_trait::async_trait]
-impl Request for EditInlineMessageLiveLocation {
+impl RequestOld for EditInlineMessageLiveLocation {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/edit_inline_message_media.rs
+++ b/src/requests/all/edit_inline_message_media.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, InputMedia, True},
     Bot,
 };
@@ -30,7 +30,7 @@ pub struct EditInlineMessageMedia {
 }
 
 #[async_trait::async_trait]
-impl Request for EditInlineMessageMedia {
+impl RequestOld for EditInlineMessageMedia {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/edit_inline_message_reply_markup.rs
+++ b/src/requests/all/edit_inline_message_reply_markup.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, True},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct EditInlineMessageReplyMarkup {
 }
 
 #[async_trait::async_trait]
-impl Request for EditInlineMessageReplyMarkup {
+impl RequestOld for EditInlineMessageReplyMarkup {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/edit_inline_message_text.rs
+++ b/src/requests/all/edit_inline_message_text.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, Message, ParseMode},
     Bot,
 };
@@ -27,7 +27,7 @@ pub struct EditInlineMessageText {
 }
 
 #[async_trait::async_trait]
-impl Request for EditInlineMessageText {
+impl RequestOld for EditInlineMessageText {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/edit_message_caption.rs
+++ b/src/requests/all/edit_message_caption.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Message, ParseMode},
     Bot,
 };
@@ -27,7 +27,7 @@ pub struct EditMessageCaption {
 }
 
 #[async_trait::async_trait]
-impl Request for EditMessageCaption {
+impl RequestOld for EditMessageCaption {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/edit_message_live_location.rs
+++ b/src/requests/all/edit_message_live_location.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Message},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct EditMessageLiveLocation {
 }
 
 #[async_trait::async_trait]
-impl Request for EditMessageLiveLocation {
+impl RequestOld for EditMessageLiveLocation {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/edit_message_media.rs
+++ b/src/requests/all/edit_message_media.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, InputMedia, Message},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct EditMessageMedia {
 }
 
 #[async_trait::async_trait]
-impl Request for EditMessageMedia {
+impl RequestOld for EditMessageMedia {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/edit_message_reply_markup.rs
+++ b/src/requests/all/edit_message_reply_markup.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Message},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct EditMessageReplyMarkup {
 }
 
 #[async_trait::async_trait]
-impl Request for EditMessageReplyMarkup {
+impl RequestOld for EditMessageReplyMarkup {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/edit_message_text.rs
+++ b/src/requests/all/edit_message_text.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Message, ParseMode},
     Bot,
 };
@@ -28,7 +28,7 @@ pub struct EditMessageText {
 }
 
 #[async_trait::async_trait]
-impl Request for EditMessageText {
+impl RequestOld for EditMessageText {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/export_chat_invite_link.rs
+++ b/src/requests/all/export_chat_invite_link.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::ChatId,
     Bot,
 };
@@ -35,7 +35,7 @@ pub struct ExportChatInviteLink {
 }
 
 #[async_trait::async_trait]
-impl Request for ExportChatInviteLink {
+impl RequestOld for ExportChatInviteLink {
     type Output = String;
 
     /// Returns the new invite link as `String` on success.

--- a/src/requests/all/forward_message.rs
+++ b/src/requests/all/forward_message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message},
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct ForwardMessage {
 }
 
 #[async_trait::async_trait]
-impl Request for ForwardMessage {
+impl RequestOld for ForwardMessage {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/get_chat.rs
+++ b/src/requests/all/get_chat.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{Chat, ChatId},
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct GetChat {
 }
 
 #[async_trait::async_trait]
-impl Request for GetChat {
+impl RequestOld for GetChat {
     type Output = Chat;
 
     async fn send(&self) -> ResponseResult<Chat> {

--- a/src/requests/all/get_chat_administrators.rs
+++ b/src/requests/all/get_chat_administrators.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, ChatMember},
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct GetChatAdministrators {
 }
 
 #[async_trait::async_trait]
-impl Request for GetChatAdministrators {
+impl RequestOld for GetChatAdministrators {
     type Output = Vec<ChatMember>;
 
     /// On success, returns an array that contains information about all chat

--- a/src/requests/all/get_chat_member.rs
+++ b/src/requests/all/get_chat_member.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, ChatMember},
     Bot,
 };
@@ -20,7 +20,7 @@ pub struct GetChatMember {
 }
 
 #[async_trait::async_trait]
-impl Request for GetChatMember {
+impl RequestOld for GetChatMember {
     type Output = ChatMember;
 
     async fn send(&self) -> ResponseResult<ChatMember> {

--- a/src/requests/all/get_chat_members_count.rs
+++ b/src/requests/all/get_chat_members_count.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::ChatId,
     Bot,
 };
@@ -19,7 +19,7 @@ pub struct GetChatMembersCount {
 }
 
 #[async_trait::async_trait]
-impl Request for GetChatMembersCount {
+impl RequestOld for GetChatMembersCount {
     type Output = i32;
 
     async fn send(&self) -> ResponseResult<i32> {

--- a/src/requests/all/get_file.rs
+++ b/src/requests/all/get_file.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::File,
     Bot,
 };
@@ -35,7 +35,7 @@ pub struct GetFile {
 }
 
 #[async_trait::async_trait]
-impl Request for GetFile {
+impl RequestOld for GetFile {
     type Output = File;
 
     async fn send(&self) -> ResponseResult<File> {

--- a/src/requests/all/get_game_high_scores.rs
+++ b/src/requests/all/get_game_high_scores.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{GameHighScore, TargetMessage},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct GetGameHighScores {
 }
 
 #[async_trait::async_trait]
-impl Request for GetGameHighScores {
+impl RequestOld for GetGameHighScores {
     type Output = Vec<GameHighScore>;
 
     async fn send(&self) -> ResponseResult<Vec<GameHighScore>> {

--- a/src/requests/all/get_me.rs
+++ b/src/requests/all/get_me.rs
@@ -1,6 +1,6 @@
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::Me,
     Bot,
 };
@@ -16,7 +16,7 @@ pub struct GetMe {
 }
 
 #[async_trait::async_trait]
-impl Request for GetMe {
+impl RequestOld for GetMe {
     type Output = Me;
 
     /// Returns basic information about the bot.

--- a/src/requests/all/get_my_commands.rs
+++ b/src/requests/all/get_my_commands.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::BotCommand,
     Bot,
 };
@@ -18,7 +18,7 @@ pub struct GetMyCommands {
 }
 
 #[async_trait::async_trait]
-impl Request for GetMyCommands {
+impl RequestOld for GetMyCommands {
     type Output = Vec<BotCommand>;
 
     async fn send(&self) -> ResponseResult<Self::Output> {

--- a/src/requests/all/get_sticker_set.rs
+++ b/src/requests/all/get_sticker_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::StickerSet,
     Bot,
 };
@@ -19,7 +19,7 @@ pub struct GetStickerSet {
 }
 
 #[async_trait::async_trait]
-impl Request for GetStickerSet {
+impl RequestOld for GetStickerSet {
     type Output = StickerSet;
 
     async fn send(&self) -> ResponseResult<StickerSet> {

--- a/src/requests/all/get_updates.rs
+++ b/src/requests/all/get_updates.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{AllowedUpdate, Update},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct GetUpdates {
 }
 
 #[async_trait::async_trait]
-impl Request for GetUpdates {
+impl RequestOld for GetUpdates {
     type Output = Vec<Update>;
 
     async fn send(&self) -> ResponseResult<Self::Output> {

--- a/src/requests/all/get_updates_non_strict.rs
+++ b/src/requests/all/get_updates_non_strict.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{GetUpdates, Request, ResponseResult},
+    requests::{GetUpdates, RequestOld, ResponseResult},
     types::{AllowedUpdate, NonStrictVec, Update},
     Bot,
 };
@@ -20,7 +20,7 @@ use crate::{
 pub struct GetUpdatesNonStrict(pub GetUpdates);
 
 #[async_trait::async_trait]
-impl Request for GetUpdatesNonStrict {
+impl RequestOld for GetUpdatesNonStrict {
     type Output = NonStrictVec<Update>;
 
     async fn send(&self) -> ResponseResult<Self::Output> {

--- a/src/requests/all/get_user_profile_photos.rs
+++ b/src/requests/all/get_user_profile_photos.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::UserProfilePhotos,
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct GetUserProfilePhotos {
 }
 
 #[async_trait::async_trait]
-impl Request for GetUserProfilePhotos {
+impl RequestOld for GetUserProfilePhotos {
     type Output = UserProfilePhotos;
 
     async fn send(&self) -> ResponseResult<UserProfilePhotos> {

--- a/src/requests/all/get_webhook_info.rs
+++ b/src/requests/all/get_webhook_info.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::WebhookInfo,
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct GetWebhookInfo {
 }
 
 #[async_trait::async_trait]
-impl Request for GetWebhookInfo {
+impl RequestOld for GetWebhookInfo {
     type Output = WebhookInfo;
 
     #[allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/requests/all/kick_chat_member.rs
+++ b/src/requests/all/kick_chat_member.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -28,7 +28,7 @@ pub struct KickChatMember {
 }
 
 #[async_trait::async_trait]
-impl Request for KickChatMember {
+impl RequestOld for KickChatMember {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/leave_chat.rs
+++ b/src/requests/all/leave_chat.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -19,7 +19,7 @@ pub struct LeaveChat {
 }
 
 #[async_trait::async_trait]
-impl Request for LeaveChat {
+impl RequestOld for LeaveChat {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/pin_chat_message.rs
+++ b/src/requests/all/pin_chat_message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct PinChatMessage {
 }
 
 #[async_trait::async_trait]
-impl Request for PinChatMessage {
+impl RequestOld for PinChatMessage {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/promote_chat_member.rs
+++ b/src/requests/all/promote_chat_member.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -32,7 +32,7 @@ pub struct PromoteChatMember {
 }
 
 #[async_trait::async_trait]
-impl Request for PromoteChatMember {
+impl RequestOld for PromoteChatMember {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/restrict_chat_member.rs
+++ b/src/requests/all/restrict_chat_member.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, ChatPermissions, True},
     Bot,
 };
@@ -26,7 +26,7 @@ pub struct RestrictChatMember {
 }
 
 #[async_trait::async_trait]
-impl Request for RestrictChatMember {
+impl RequestOld for RestrictChatMember {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/send_animation.rs
+++ b/src/requests/all/send_animation.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -33,7 +33,7 @@ pub struct SendAnimation {
 }
 
 #[async_trait::async_trait]
-impl Request for SendAnimation {
+impl RequestOld for SendAnimation {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_audio.rs
+++ b/src/requests/all/send_audio.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -37,7 +37,7 @@ pub struct SendAudio {
 }
 
 #[async_trait::async_trait]
-impl Request for SendAudio {
+impl RequestOld for SendAudio {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_chat_action.rs
+++ b/src/requests/all/send_chat_action.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -71,7 +71,7 @@ pub enum SendChatActionKind {
 }
 
 #[async_trait::async_trait]
-impl Request for SendChatAction {
+impl RequestOld for SendChatAction {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/send_contact.rs
+++ b/src/requests/all/send_contact.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message, ReplyMarkup},
     Bot,
 };
@@ -26,7 +26,7 @@ pub struct SendContact {
 }
 
 #[async_trait::async_trait]
-impl Request for SendContact {
+impl RequestOld for SendContact {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_dice.rs
+++ b/src/requests/all/send_dice.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, DiceEmoji, Message, ReplyMarkup},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct SendDice {
 }
 
 #[async_trait::async_trait]
-impl Request for SendDice {
+impl RequestOld for SendDice {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_document.rs
+++ b/src/requests/all/send_document.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct SendDocument {
 }
 
 #[async_trait::async_trait]
-impl Request for SendDocument {
+impl RequestOld for SendDocument {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_game.rs
+++ b/src/requests/all/send_game.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, Message},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct SendGame {
 }
 
 #[async_trait::async_trait]
-impl Request for SendGame {
+impl RequestOld for SendGame {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_invoice.rs
+++ b/src/requests/all/send_invoice.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, LabeledPrice, Message},
     Bot,
 };
@@ -41,7 +41,7 @@ pub struct SendInvoice {
 }
 
 #[async_trait::async_trait]
-impl Request for SendInvoice {
+impl RequestOld for SendInvoice {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_location.rs
+++ b/src/requests/all/send_location.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message, ReplyMarkup},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct SendLocation {
 }
 
 #[async_trait::async_trait]
-impl Request for SendLocation {
+impl RequestOld for SendLocation {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_media_group.rs
+++ b/src/requests/all/send_media_group.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputMedia, Message},
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct SendMediaGroup {
 }
 
 #[async_trait::async_trait]
-impl Request for SendMediaGroup {
+impl RequestOld for SendMediaGroup {
     type Output = Vec<Message>;
 
     async fn send(&self) -> ResponseResult<Vec<Message>> {

--- a/src/requests/all/send_message.rs
+++ b/src/requests/all/send_message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct SendMessage {
 }
 
 #[async_trait::async_trait]
-impl Request for SendMessage {
+impl RequestOld for SendMessage {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_photo.rs
+++ b/src/requests/all/send_photo.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct SendPhoto {
 }
 
 #[async_trait::async_trait]
-impl Request for SendPhoto {
+impl RequestOld for SendPhoto {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_poll.rs
+++ b/src/requests/all/send_poll.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message, ParseMode, PollType, ReplyMarkup},
     Bot,
 };
@@ -33,7 +33,7 @@ pub struct SendPoll {
 }
 
 #[async_trait::async_trait]
-impl Request for SendPoll {
+impl RequestOld for SendPoll {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_sticker.rs
+++ b/src/requests/all/send_sticker.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ReplyMarkup},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct SendSticker {
 }
 
 #[async_trait::async_trait]
-impl Request for SendSticker {
+impl RequestOld for SendSticker {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_venue.rs
+++ b/src/requests/all/send_venue.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, Message, ReplyMarkup},
     Bot,
 };
@@ -28,7 +28,7 @@ pub struct SendVenue {
 }
 
 #[async_trait::async_trait]
-impl Request for SendVenue {
+impl RequestOld for SendVenue {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_video.rs
+++ b/src/requests/all/send_video.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -34,7 +34,7 @@ pub struct SendVideo {
 }
 
 #[async_trait::async_trait]
-impl Request for SendVideo {
+impl RequestOld for SendVideo {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_video_note.rs
+++ b/src/requests/all/send_video_note.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ReplyMarkup},
     Bot,
 };
@@ -29,7 +29,7 @@ pub struct SendVideoNote {
 }
 
 #[async_trait::async_trait]
-impl Request for SendVideoNote {
+impl RequestOld for SendVideoNote {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/send_voice.rs
+++ b/src/requests/all/send_voice.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, Message, ParseMode, ReplyMarkup},
     Bot,
 };
@@ -35,7 +35,7 @@ pub struct SendVoice {
 }
 
 #[async_trait::async_trait]
-impl Request for SendVoice {
+impl RequestOld for SendVoice {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/set_chat_administrator_custom_title.rs
+++ b/src/requests/all/set_chat_administrator_custom_title.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct SetChatAdministratorCustomTitle {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatAdministratorCustomTitle {
+impl RequestOld for SetChatAdministratorCustomTitle {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_chat_description.rs
+++ b/src/requests/all/set_chat_description.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -24,7 +24,7 @@ pub struct SetChatDescription {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatDescription {
+impl RequestOld for SetChatDescription {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_chat_permissions.rs
+++ b/src/requests/all/set_chat_permissions.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, ChatPermissions, True},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct SetChatPermissions {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatPermissions {
+impl RequestOld for SetChatPermissions {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_chat_photo.rs
+++ b/src/requests/all/set_chat_photo.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InputFile, True},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct SetChatPhoto {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatPhoto {
+impl RequestOld for SetChatPhoto {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_chat_sticker_set.rs
+++ b/src/requests/all/set_chat_sticker_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -24,7 +24,7 @@ pub struct SetChatStickerSet {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatStickerSet {
+impl RequestOld for SetChatStickerSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_chat_title.rs
+++ b/src/requests/all/set_chat_title.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct SetChatTitle {
 }
 
 #[async_trait::async_trait]
-impl Request for SetChatTitle {
+impl RequestOld for SetChatTitle {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_game_score.rs
+++ b/src/requests/all/set_game_score.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{Message, TargetMessage},
     Bot,
 };
@@ -32,7 +32,7 @@ pub struct SetGameScore {
 }
 
 #[async_trait::async_trait]
-impl Request for SetGameScore {
+impl RequestOld for SetGameScore {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/set_my_commands.rs
+++ b/src/requests/all/set_my_commands.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{BotCommand, True},
     Bot,
 };
@@ -20,7 +20,7 @@ pub struct SetMyCommands {
 }
 
 #[async_trait::async_trait]
-impl Request for SetMyCommands {
+impl RequestOld for SetMyCommands {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<Self::Output> {

--- a/src/requests/all/set_sticker_position_in_set.rs
+++ b/src/requests/all/set_sticker_position_in_set.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::True,
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct SetStickerPositionInSet {
 }
 
 #[async_trait::async_trait]
-impl Request for SetStickerPositionInSet {
+impl RequestOld for SetStickerPositionInSet {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/set_sticker_set_thumb.rs
+++ b/src/requests/all/set_sticker_set_thumb.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InputFile, True},
     Bot,
 };
@@ -22,7 +22,7 @@ pub struct SetStickerSetThumb {
 }
 
 #[async_trait::async_trait]
-impl Request for SetStickerSetThumb {
+impl RequestOld for SetStickerSetThumb {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<Self::Output> {

--- a/src/requests/all/set_webhook.rs
+++ b/src/requests/all/set_webhook.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{AllowedUpdate, InputFile, True},
     Bot,
 };
@@ -35,7 +35,7 @@ pub struct SetWebhook {
 }
 
 #[async_trait::async_trait]
-impl Request for SetWebhook {
+impl RequestOld for SetWebhook {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/stop_inline_message_live_location.rs
+++ b/src/requests/all/stop_inline_message_live_location.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{InlineKeyboardMarkup, Message},
     Bot,
 };
@@ -25,7 +25,7 @@ pub struct StopInlineMessageLiveLocation {
 }
 
 #[async_trait::async_trait]
-impl Request for StopInlineMessageLiveLocation {
+impl RequestOld for StopInlineMessageLiveLocation {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/stop_message_live_location.rs
+++ b/src/requests/all/stop_message_live_location.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Message},
     Bot,
 };
@@ -26,7 +26,7 @@ pub struct StopMessageLiveLocation {
 }
 
 #[async_trait::async_trait]
-impl Request for StopMessageLiveLocation {
+impl RequestOld for StopMessageLiveLocation {
     type Output = Message;
 
     async fn send(&self) -> ResponseResult<Message> {

--- a/src/requests/all/stop_poll.rs
+++ b/src/requests/all/stop_poll.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, InlineKeyboardMarkup, Poll},
     Bot,
 };
@@ -21,7 +21,7 @@ pub struct StopPoll {
 }
 
 #[async_trait::async_trait]
-impl Request for StopPoll {
+impl RequestOld for StopPoll {
     type Output = Poll;
 
     /// On success, the stopped [`Poll`] with the final results is returned.

--- a/src/requests/all/unban_chat_member.rs
+++ b/src/requests/all/unban_chat_member.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct UnbanChatMember {
 }
 
 #[async_trait::async_trait]
-impl Request for UnbanChatMember {
+impl RequestOld for UnbanChatMember {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/unpin_chat_message.rs
+++ b/src/requests/all/unpin_chat_message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{ChatId, True},
     Bot,
 };
@@ -23,7 +23,7 @@ pub struct UnpinChatMessage {
 }
 
 #[async_trait::async_trait]
-impl Request for UnpinChatMessage {
+impl RequestOld for UnpinChatMessage {
     type Output = True;
 
     async fn send(&self) -> ResponseResult<True> {

--- a/src/requests/all/upload_sticker_file.rs
+++ b/src/requests/all/upload_sticker_file.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     net,
-    requests::{Request, ResponseResult},
+    requests::{RequestOld, ResponseResult},
     types::{File, InputFile},
     Bot,
 };
@@ -24,7 +24,7 @@ pub struct UploadStickerFile {
     png_sticker: InputFile,
 }
 #[async_trait::async_trait]
-impl Request for UploadStickerFile {
+impl RequestOld for UploadStickerFile {
     type Output = File;
 
     async fn send(&self) -> ResponseResult<File> {

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -1,0 +1,45 @@
+use crate::requests::Payload;
+
+/// Represent types that have payload inside it. E.g.: the payload itself or a
+/// `Request`.
+///
+/// This trait is something between [`DerefMut`] and [`BorrowMut`] — it allows
+/// only one implementation per type (the [output] is associated type, not a
+/// generic), have implementations for all types `P` such `P: `[`Payload`], but
+/// have no magic compiler support like [`DerefMut`] does nor does it require
+/// any laws about `Eq`, `Ord` and `Hash` as [`BorrowMut`] does.
+///
+/// Also [output] type is bounded by [`Payload`] trait.
+///
+/// This trait is mostly used to implement payload setters (on both payloads &
+/// requests), so you probably won't find yourself using it directly.
+///
+/// [`DerefMut`]: std::ops::DerefMut
+/// [`BorrowMut`]: std::borrow::BorrowMut
+/// [`Payload`]: crate::requests::Payload
+/// [output]: HasPayload::Payload
+pub trait HasPayload {
+    /// Type of the payload contained.
+    type Payload: Payload;
+
+    /// Gain mutable access to the underlying payload.
+    fn payload_mut(&mut self) -> &mut Self::Payload;
+
+    /// Gain immutable access to the underlying payload.
+    fn payload_ref(&self) -> &Self::Payload;
+}
+
+impl<P> HasPayload for P
+where
+    P: Payload,
+{
+    type Payload = Self;
+
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        self
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        self
+    }
+}

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -18,7 +18,9 @@ use crate::requests::Payload;
 /// [`BorrowMut`]: std::borrow::BorrowMut
 /// [`Payload`]: crate::requests::Payload
 /// [output]: HasPayload::Payload
-pub trait HasPayload: AsMut<<Self as HasPayload>::Payload> + AsRef<<Self as HasPayload>::Payload> {
+pub trait HasPayload:
+    AsMut<<Self as HasPayload>::Payload> + AsRef<<Self as HasPayload>::Payload>
+{
     /// Type of the payload contained.
     type Payload: Payload;
 

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -18,15 +18,19 @@ use crate::requests::Payload;
 /// [`BorrowMut`]: std::borrow::BorrowMut
 /// [`Payload`]: crate::requests::Payload
 /// [output]: HasPayload::Payload
-pub trait HasPayload {
+pub trait HasPayload: AsMut<<Self as HasPayload>::Payload> + AsRef<<Self as HasPayload>::Payload> {
     /// Type of the payload contained.
     type Payload: Payload;
 
     /// Gain mutable access to the underlying payload.
-    fn payload_mut(&mut self) -> &mut Self::Payload;
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        self.as_mut()
+    }
 
     /// Gain immutable access to the underlying payload.
-    fn payload_ref(&self) -> &Self::Payload;
+    fn payload_ref(&self) -> &Self::Payload {
+        self.as_ref()
+    }
 }
 
 impl<P> HasPayload for P
@@ -34,12 +38,4 @@ where
     P: Payload,
 {
     type Payload = Self;
-
-    fn payload_mut(&mut self) -> &mut Self::Payload {
-        self
-    }
-
-    fn payload_ref(&self) -> &Self::Payload {
-        self
-    }
 }

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,5 +1,11 @@
 //! API requests.
 
+mod has_payload;
+mod payload;
+mod request;
+
+pub use self::{has_payload::HasPayload, payload::Payload, request::Request};
+
 mod all;
 mod utils;
 
@@ -7,6 +13,10 @@ pub use all::*;
 
 /// A type that is returned after making a request to Telegram.
 pub type ResponseResult<T> = Result<T, crate::RequestError>;
+
+/// Output of a [`Payload`] in [`HasPayload`]. Alias to
+/// `<<T as HasPayload>::Payload as Payload>::Output`.
+pub type Output<T> = <<T as HasPayload>::Payload as Payload>::Output;
 
 /// Designates an API request.
 #[async_trait::async_trait]

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -10,7 +10,7 @@ pub type ResponseResult<T> = Result<T, crate::RequestError>;
 
 /// Designates an API request.
 #[async_trait::async_trait]
-pub trait Request {
+pub trait RequestOld {
     /// A data structure returned if success.
     type Output;
 

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -6,7 +6,7 @@
 /// This trait provides some additional information needed for sending request
 /// to the telegram.
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
-pub trait Payload {
+pub trait Payload: AsMut<Self> + AsRef<Self> {
     /// Return type of the telegram method.
     ///
     /// Note: that should not include result wrappers (e.g. it should be simply

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -1,0 +1,20 @@
+/// Payload of a request.
+///
+/// Simply speaking structs implementing this trait represent arguments of
+/// a telegram bot API method.
+///
+/// This trait provides some additional information needed for sending request
+/// to the telegram.
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
+pub trait Payload {
+    /// Return type of the telegram method.
+    ///
+    /// Note: that should not include result wrappers (e.g. it should be simply
+    /// `Message`, `True` or something else)
+    type Output;
+
+    /// Name of the telegram method. Case insensitive, though must not include
+    /// underscores. (e.g.: `GetMe`, `GETME`, `getme`, `getMe` are ok, but
+    /// `get_me` is not ok)
+    const NAME: &'static str;
+}

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -1,0 +1,69 @@
+use std::future::Future;
+
+use crate::requests::{HasPayload, Output};
+
+/// A ready-to-send telegram request.
+// FIXME(waffle): Write better doc for the trait
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
+pub trait Request: HasPayload {
+    /*
+     * Could be mostly `core::future::IntoFuture` though there is no reason to
+     * use it before it's integrated in async/await
+     */
+
+    /// Type of error that may happen during sending the request to telegram.
+    type Err;
+
+    /// Type of future returned by [`send`](Request::send) method.
+    type Send: Future<Output = Result<Output<Self>, Self::Err>>;
+
+    /// Type of future returned by [`send_ref`](Request::send_ref) method.
+    ///
+    /// NOTE: it intentionally forbids borrowing from self
+    // though anyway we couldn't allow borrowing without GATs :sob:
+    type SendRef: Future<Output = Result<Output<Self>, Self::Err>>;
+
+    /// Send the request.
+    ///
+    /// ## Examples
+    // FIXME(waffle): ignored until full request redesign lands
+    /// ```ignore
+    /// # async {
+    /// use teloxide_core::{methods::GetMe, requests::{Request, RequestJson}, types::User, bot::Bot};
+    ///
+    /// let bot = Bot::new("TOKEN");
+    /// let method = GetMe::new();
+    /// let request = JsonRequest::new(bot, method);
+    /// let _: User = request.send().await.unwrap();
+    /// # }
+    /// ```
+    fn send(self) -> Self::Send;
+
+    /// Send the request.
+    ///
+    /// This method is analogous to [`send`](Request::send), but it doesn't take
+    /// the ownership of `self`. This allows to send the same (or slightly
+    /// different) requests over and over.
+    ///
+    /// _Also_ it is expected that calling this method is better than just
+    /// `clone`ing the requests. (because instead of copying all the data
+    /// and then serializing it, this method should just serialize the data)
+    ///
+    /// ## Examples
+    // FIXME(waffle): ignored until full request redisign lands
+    /// ```ignore
+    /// # async {
+    /// use teloxide_core::prelude::*;
+    ///
+    /// let bot = Bot::new("TOKEN");
+    /// # let chat_ids = vec![1, 2, 3, 4].into_iter().map(Into::into);
+    ///
+    /// let mut req = bot.send_message(0, "Hi there!");
+    /// for chat_id in chat_ids {
+    ///     req.chat_id = chat_id;
+    ///     req.send_ref().await.unwrap();
+    /// }
+    /// # }
+    /// ```
+    fn send_ref(&self) -> Self::SendRef;
+}


### PR DESCRIPTION
This is part of https://github.com/teloxide/teloxide/issues/265

This PR
- Renames `Request` => `RequestOld` (`RequestOld` will be removed in followup PRs)
- Adds 3 traits mentioned in https://github.com/teloxide/teloxide/issues/265:
  + `Payload`
  + `HasPayload`
  + `Request`
- Adds `Output<T>` alias to `<<T as HasPayload>::Payload as Payload>::Output`