### PR TITLE
implement default Bot's {Json,Multipart}Request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ authors = [
 futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["fs", "stream"] }
 tokio-util = "0.3.1"
+pin-project = "0.4.23"
 bytes = "0.5.5"
 async-trait = "0.1.36"
 reqwest = { version = "0.10.6", features = ["json", "stream"] }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,7 +3,7 @@ pub use download::download_file_stream;
 
 pub use self::{
     download::download_file,
-    request::{request_json, request_multipart},
+    request::{request_json, request_json2, request_multipart, request_multipart2},
     telegram_response::TelegramResponse,
 };
 

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use reqwest::{Client, Response};
+use reqwest::{
+    header::{HeaderValue, CONTENT_TYPE},
+    Client, Response,
+};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -54,6 +57,50 @@ where
     let response = client
         .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
         .json(params)
+        .send()
+        .await
+        .map_err(RequestError::NetworkError)?;
+
+    process_response(response).await
+}
+
+// FIXME(waffle):
+//   request_{json,mutipart} are currently used in old code, so we keep them
+//   for now when they will not be used anymore, we should remove them
+//   and rename request_{json,mutipart}2 => request_{json,mutipart}
+
+pub async fn request_multipart2<T>(
+    client: &Client,
+    token: &str,
+    method_name: &str,
+    params: reqwest::multipart::Form,
+) -> ResponseResult<T>
+where
+    T: DeserializeOwned,
+{
+    let response = client
+        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .multipart(params)
+        .send()
+        .await
+        .map_err(RequestError::NetworkError)?;
+
+    process_response(response).await
+}
+
+pub async fn request_json2<T>(
+    client: &Client,
+    token: &str,
+    method_name: &str,
+    params: Vec<u8>,
+) -> ResponseResult<T>
+where
+    T: DeserializeOwned,
+{
+    let response = client
+        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+        .body(params)
         .send()
         .await
         .map_err(RequestError::NetworkError)?;

--- a/src/requests/json.rs
+++ b/src/requests/json.rs
@@ -1,0 +1,106 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    bot::Bot,
+    requests::{HasPayload, Payload, Request, ResponseResult},
+    RequestError,
+};
+
+/// Ready-to-send telegram request.
+///
+/// Note: payload will be sent to telegram using [`json`]
+///
+/// [`json`]: https://core.telegram.org/bots/api#making-requests
+#[must_use = "requests do nothing until sent"]
+pub struct JsonRequest<P> {
+    bot: Bot,
+    payload: P,
+}
+
+impl<P> JsonRequest<P> {
+    pub const fn new(bot: Bot, payload: P) -> Self {
+        Self { bot, payload }
+    }
+}
+
+impl<P> Request for JsonRequest<P>
+where
+    // FIXME(waffle):
+    //   this is required on stable because of
+    //   https://github.com/rust-lang/rust/issues/76882
+    //   when it's resolved or `type_alias_impl_trait` feature
+    //   stabilized, we should remove 'static restriction
+    //
+    // (though critically, currently we have no
+    // non-'static payloads)
+    P: 'static,
+    P: Payload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    type Err = RequestError;
+    type Send = Send<P>;
+    type SendRef = SendRef<P>;
+
+    fn send(self) -> Self::Send {
+        Send::new(self)
+    }
+
+    fn send_ref(&self) -> Self::SendRef {
+        SendRef::new(self)
+    }
+}
+
+impl<P> HasPayload for JsonRequest<P>
+where
+    P: Payload,
+{
+    type Payload = P;
+}
+
+impl<P> AsRef<P> for JsonRequest<P> {
+    fn as_ref(&self) -> &P {
+        &self.payload
+    }
+}
+
+impl<P> AsMut<P> for JsonRequest<P> {
+    fn as_mut(&mut self) -> &mut P {
+        &mut self.payload
+    }
+}
+
+impl<P: Payload + Serialize> core::ops::Deref for JsonRequest<P> {
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<P: Payload + Serialize> core::ops::DerefMut for JsonRequest<P> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
+req_future! {
+    def: |it: JsonRequest<U>| {
+        it.bot.execute_json(&it.payload)
+    }
+    pub Send<U> (inner0) -> ResponseResult<U::Output>
+    where
+        U: 'static,
+        U: Payload + Serialize,
+        U::Output: DeserializeOwned,
+}
+
+req_future! {
+    def: |it: &JsonRequest<U>| {
+        it.bot.execute_json(&it.payload)
+    }
+    pub SendRef<U> (inner1) -> ResponseResult<U::Output>
+    where
+        U: 'static,
+        U: Payload + Serialize,
+        U::Output: DeserializeOwned,
+}

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -7,9 +7,13 @@ mod request;
 pub use self::{has_payload::HasPayload, payload::Payload, request::Request};
 
 mod all;
+mod json;
+mod multipart;
 mod utils;
 
 pub use all::*;
+pub use json::JsonRequest;
+pub use multipart::MultipartRequest;
 
 /// A type that is returned after making a request to Telegram.
 pub type ResponseResult<T> = Result<T, crate::RequestError>;

--- a/src/requests/multipart.rs
+++ b/src/requests/multipart.rs
@@ -1,0 +1,116 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    bot::Bot,
+    requests::{HasPayload, Payload, Request, ResponseResult},
+    RequestError,
+};
+
+/// Ready-to-send telegram request.
+///
+/// Note: payload will be sent to telegram using [`multipart/form-data`]
+///
+/// [`multipart/form-data`]: https://core.telegram.org/bots/api#making-requests
+#[must_use = "requests do nothing until sent"]
+pub struct MultipartRequest<P> {
+    bot: Bot,
+    payload: P,
+}
+
+impl<P> MultipartRequest<P> {
+    pub fn new(bot: Bot, payload: P) -> Self {
+        Self { bot, payload }
+    }
+}
+
+impl<P> Request for MultipartRequest<P>
+where
+    // FIXME(waffle):
+    //   this is required on stable because of
+    //   https://github.com/rust-lang/rust/issues/76882
+    //   when it's resolved or `type_alias_impl_trait` feature
+    //   stabilized, we should remove 'static restriction
+    //
+    // (though critically, currently we have no
+    // non-'static payloads)
+    P: 'static,
+    P: Payload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    type Err = RequestError;
+    type Send = Send<P>;
+    type SendRef = SendRef<P>;
+
+    fn send(self) -> Self::Send {
+        Send::new(self)
+    }
+
+    fn send_ref(&self) -> Self::SendRef {
+        SendRef::new(self)
+    }
+}
+
+impl<P> HasPayload for MultipartRequest<P>
+where
+    P: Payload,
+{
+    type Payload = P;
+}
+
+impl<P> AsRef<P> for MultipartRequest<P> {
+    fn as_ref(&self) -> &P {
+        &self.payload
+    }
+}
+
+impl<P> AsMut<P> for MultipartRequest<P> {
+    fn as_mut(&mut self) -> &mut P {
+        &mut self.payload
+    }
+}
+
+impl<P> core::ops::Deref for MultipartRequest<P>
+where
+    P: 'static,
+    P: Payload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<P> core::ops::DerefMut for MultipartRequest<P>
+where
+    P: 'static,
+    P: Payload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
+req_future! {
+    def: |it: MultipartRequest<U>| {
+        it.bot.execute_multipart(&it.payload)
+    }
+    pub Send<U> (inner0) -> ResponseResult<U::Output>
+    where
+        U: 'static,
+        U: Payload + Serialize,
+        U::Output: DeserializeOwned,
+}
+
+req_future! {
+    def: |it: &MultipartRequest<U>| {
+        it.bot.execute_multipart(&it.payload)
+    }
+    pub SendRef<U> (inner1) -> ResponseResult<U::Output>
+    where
+        U: 'static,
+        U: Payload + Serialize,
+        U::Output: DeserializeOwned,
+}

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -50,7 +50,7 @@ pub trait Request: HasPayload {
     /// and then serializing it, this method should just serialize the data)
     ///
     /// ## Examples
-    // FIXME(waffle): ignored until full request redisign lands
+    // FIXME(waffle): ignored until full request redesign lands
     /// ```ignore
     /// # async {
     /// use teloxide_core::prelude::*;

--- a/src/serde_multipart/serializers.rs
+++ b/src/serde_multipart/serializers.rs
@@ -1,6 +1,7 @@
 use crate::{
     serde_multipart::unserializers::{InputFileUnserializer, StringUnserializer},
     types::InputFile,
+    RequestError,
 };
 use futures::{
     future::{ready, BoxFuture},
@@ -50,6 +51,20 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
+    }
+}
+
+impl From<Error> for RequestError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::Io(ioerr) => RequestError::Io(ioerr),
+            // this should be ok since we don't write request those may trigger errors and
+            // Error is internal.
+            _ => unreachable!(
+                "we don't create requests those fail to serialize (if you see this, open an issue \
+                 :|)"
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
Implement default Bot's requests structs. 
This is part of requests redisign.﻿

Those structs will be returned from `<Bot as Requestor>` methods once we'll implement Requestor.

Note: we create induvidual structs for Send/SendRef so we could use exhastential types on nightly (`feature(type_alias_impl_trait)`) while using `Box`ing on stable.
﻿