### PR TITLE
Requests redisign part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ uuid = { version = "0.8.1", features = ["v4"] } # for attaching input files
 derive_more = "0.99.9"
 mime = "0.3.16"
 thiserror = "1.0.20"
+once_cell = "1.4.0"
 
 [features]
 # features those require nightly compiler

--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -1,4 +1,5 @@
 use crate::{
+    payloads,
     requests::{
         AddStickerToSet, AnswerCallbackQuery, AnswerInlineQuery, AnswerPreCheckoutQuery,
         AnswerShippingQuery, CreateNewStickerSet, DeleteChatPhoto, DeleteChatStickerSet,
@@ -8,14 +9,15 @@ use crate::{
         EditMessageReplyMarkup, EditMessageText, ExportChatInviteLink, ForwardMessage, GetChat,
         GetChatAdministrators, GetChatMember, GetChatMembersCount, GetFile, GetGameHighScores,
         GetMe, GetMyCommands, GetStickerSet, GetUpdates, GetUpdatesNonStrict, GetUserProfilePhotos,
-        GetWebhookInfo, KickChatMember, LeaveChat, PinChatMessage, PromoteChatMember,
-        RestrictChatMember, SendAnimation, SendAudio, SendChatAction, SendChatActionKind,
-        SendContact, SendDice, SendDocument, SendGame, SendInvoice, SendLocation, SendMediaGroup,
-        SendMessage, SendPhoto, SendPoll, SendSticker, SendVenue, SendVideo, SendVideoNote,
-        SendVoice, SetChatAdministratorCustomTitle, SetChatDescription, SetChatPermissions,
-        SetChatPhoto, SetChatStickerSet, SetChatTitle, SetGameScore, SetMyCommands,
-        SetStickerPositionInSet, SetStickerSetThumb, SetWebhook, StopInlineMessageLiveLocation,
-        StopMessageLiveLocation, StopPoll, UnbanChatMember, UnpinChatMessage, UploadStickerFile,
+        GetWebhookInfo, JsonRequest, KickChatMember, LeaveChat, PinChatMessage, PromoteChatMember,
+        Requester, RestrictChatMember, SendAnimation, SendAudio, SendChatAction,
+        SendChatActionKind, SendContact, SendDice, SendDocument, SendGame, SendInvoice,
+        SendLocation, SendMediaGroup, SendMessage, SendPhoto, SendPoll, SendSticker, SendVenue,
+        SendVideo, SendVideoNote, SendVoice, SetChatAdministratorCustomTitle, SetChatDescription,
+        SetChatPermissions, SetChatPhoto, SetChatStickerSet, SetChatTitle, SetGameScore,
+        SetMyCommands, SetStickerPositionInSet, SetStickerSetThumb, SetWebhook,
+        StopInlineMessageLiveLocation, StopMessageLiveLocation, StopPoll, UnbanChatMember,
+        UnpinChatMessage, UploadStickerFile,
     },
     types::{
         BotCommand, ChatId, ChatPermissions, InlineQueryResult, InputFile, InputMedia,
@@ -1699,5 +1701,13 @@ impl Bot {
             None => builder,
             Some(parse_mode) => f(builder, parse_mode),
         }
+    }
+}
+
+impl Requester for Bot {
+    type GetMe = JsonRequest<payloads::GetMe>;
+
+    fn get_me(&self) -> JsonRequest<payloads::GetMe> {
+        Self::GetMe::new(self.clone(), payloads::GetMe::new())
     }
 }

--- a/src/bot/cache_me.rs
+++ b/src/bot/cache_me.rs
@@ -1,0 +1,155 @@
+use std::{pin::Pin, sync::Arc};
+
+use futures::{
+    future,
+    future::{ok, Ready},
+    task::{Context, Poll},
+    Future,
+};
+use once_cell::sync::OnceCell;
+
+use crate::{
+    payloads::GetMe,
+    requests::{HasPayload, Request, Requester},
+    types::User,
+};
+
+/// `get_me` cache.
+///
+/// Bot's user is hardly ever changed, so sometimes it's reasonable to cache
+/// response from `get_me` method.
+pub struct CacheMe<B> {
+    bot: B,
+    me: Arc<OnceCell<User>>,
+}
+
+impl<B> CacheMe<B> {
+    /// Creates new cache.
+    ///
+    /// Note: it's recommended to use [`RequesterExt::cache_me`] instead.
+    pub fn new(bot: B) -> CacheMe<B> {
+        Self { bot, me: Arc::new(OnceCell::new()) }
+    }
+
+    /// Allows to access inner bot
+    pub fn inner(&self) -> &B {
+        &self.bot
+    }
+
+    /// Unwraps inner bot
+    pub fn into_inner(self) -> B {
+        self.bot
+    }
+
+    /// Clear cache.
+    ///
+    /// Returns cached response from `get_me`, if it was cached.
+    ///
+    /// Note: internally this uses [`Arc::make_mut`] so this will **not**
+    /// clear cache of clones of self.
+    pub fn clear(&mut self) -> Option<User> {
+        Arc::make_mut(&mut self.me).take()
+    }
+}
+
+impl<B: Requester> Requester for CacheMe<B> {
+    type GetMe = CachedMeRequest<B::GetMe>;
+
+    fn get_me(&self) -> Self::GetMe {
+        match self.me.get() {
+            Some(user) => CachedMeRequest(Inner::Ready(user.clone()), GetMe::new()),
+            None => CachedMeRequest(
+                Inner::Pending(self.bot.get_me(), Arc::clone(&self.me)),
+                GetMe::new(),
+            ),
+        }
+    }
+}
+
+pub struct CachedMeRequest<R: Request<Payload = GetMe>>(Inner<R>, GetMe);
+
+enum Inner<R: Request<Payload = GetMe>> {
+    Ready(User),
+    Pending(R, Arc<OnceCell<User>>),
+}
+
+impl<R: Request<Payload = GetMe>> Request for CachedMeRequest<R> {
+    type Err = R::Err;
+    type Send = Send<R>;
+    type SendRef = SendRef<R>;
+
+    fn send(self) -> Self::Send {
+        let fut = match self.0 {
+            Inner::Ready(user) => future::Either::Left(ok(user)),
+            Inner::Pending(req, cell) => future::Either::Right(Init(req.send(), cell)),
+        };
+        Send(fut)
+    }
+
+    fn send_ref(&self) -> Self::SendRef {
+        let fut = match &self.0 {
+            Inner::Ready(user) => future::Either::Left(ok(user.clone())),
+            Inner::Pending(req, cell) => {
+                future::Either::Right(Init(req.send_ref(), Arc::clone(cell)))
+            }
+        };
+        SendRef(fut)
+    }
+}
+
+impl<R: Request<Payload = GetMe>> HasPayload for CachedMeRequest<R> {
+    type Payload = GetMe;
+
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        &mut self.1
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        &self.1
+    }
+}
+
+type ReadyUser<Err> = Ready<Result<User, Err>>;
+
+#[pin_project::pin_project]
+pub struct Send<R: Request<Payload = GetMe>>(
+    #[pin] future::Either<ReadyUser<R::Err>, Init<R::Send, User>>,
+);
+
+impl<R: Request<Payload = GetMe>> Future for Send<R> {
+    type Output = Result<User, R::Err>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.0.poll(cx)
+    }
+}
+
+#[pin_project::pin_project]
+pub struct SendRef<R: Request<Payload = GetMe>>(
+    #[pin] future::Either<ReadyUser<R::Err>, Init<R::SendRef, User>>,
+);
+
+impl<R: Request<Payload = GetMe>> Future for SendRef<R> {
+    type Output = Result<User, R::Err>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.0.poll(cx)
+    }
+}
+
+#[pin_project::pin_project]
+struct Init<F, T>(#[pin] F, Arc<OnceCell<T>>);
+
+impl<F: Future<Output = Result<T, E>>, T: Clone, E> Future for Init<F, T> {
+    type Output = Result<T, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.0.poll(cx) {
+            Poll::Ready(Ok(ok)) => Poll::Ready(Ok(this.1.get_or_init(|| ok).clone())),
+            poll @ Poll::Ready(_) | poll @ Poll::Pending => poll,
+        }
+    }
+}

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -14,7 +14,10 @@ use crate::{
 };
 
 mod api;
+mod cache_me;
 mod download;
+
+pub use cache_me::CacheMe;
 
 pub(crate) const TELOXIDE_TOKEN: &str = "TELOXIDE_TOKEN";
 pub(crate) const TELOXIDE_PROXY: &str = "TELOXIDE_PROXY";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub use self::{
     errors::{ApiErrorKind, DownloadError, KnownApiErrorKind, RequestError},
 };
 
+pub mod payloads;
+pub mod prelude;
 pub mod requests;
 pub mod types;
 

--- a/src/payloads/get_me.rs
+++ b/src/payloads/get_me.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    requests::{HasPayload, Payload},
+    types::User,
+};
+
+/// A filter method for testing your bot's auth token. Requires no parameters.
+/// Returns basic information about the bot in form of a [`User`] object.
+///
+/// [`User`]: crate::types::User
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default, Deserialize, Serialize)]
+pub struct GetMe {}
+
+impl GetMe {
+    pub const fn new() -> Self {
+        GetMe {}
+    }
+}
+
+impl Payload for GetMe {
+    type Output = User;
+
+    const NAME: &'static str = "getMe";
+}
+
+pub trait GetMeSetters: HasPayload<Payload = GetMe> + Sized {}
+
+impl<P> GetMeSetters for P where P: HasPayload<Payload = GetMe> {}

--- a/src/payloads/mod.rs
+++ b/src/payloads/mod.rs
@@ -1,0 +1,5 @@
+pub mod setters;
+
+mod get_me;
+
+pub use get_me::{GetMe, GetMeSetters};

--- a/src/payloads/setters.rs
+++ b/src/payloads/setters.rs
@@ -1,0 +1,1 @@
+pub use crate::payloads::{GetMeSetters as _};

--- a/src/payloads/setters.rs
+++ b/src/payloads/setters.rs
@@ -1,1 +1,1 @@
-pub use crate::payloads::{GetMeSetters as _};
+pub use crate::payloads::GetMeSetters as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::requests::Requester;

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -18,21 +18,19 @@ use crate::requests::Payload;
 /// [`BorrowMut`]: std::borrow::BorrowMut
 /// [`Payload`]: crate::requests::Payload
 /// [output]: HasPayload::Payload
-pub trait HasPayload:
-    AsMut<<Self as HasPayload>::Payload> + AsRef<<Self as HasPayload>::Payload>
+pub trait HasPayload
+// FIXME(waffle):
+//   we wanted to use As{Mut,Ref} here, but they doesn't work
+//   because of https://github.com/rust-lang/rust/issues/77010
 {
     /// Type of the payload contained.
     type Payload: Payload;
 
     /// Gain mutable access to the underlying payload.
-    fn payload_mut(&mut self) -> &mut Self::Payload {
-        self.as_mut()
-    }
+    fn payload_mut(&mut self) -> &mut Self::Payload;
 
     /// Gain immutable access to the underlying payload.
-    fn payload_ref(&self) -> &Self::Payload {
-        self.as_ref()
-    }
+    fn payload_ref(&self) -> &Self::Payload;
 }
 
 impl<P> HasPayload for P
@@ -40,4 +38,12 @@ where
     P: Payload,
 {
     type Payload = Self;
+
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        self
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        self
+    }
 }

--- a/src/requests/json.rs
+++ b/src/requests/json.rs
@@ -55,17 +55,13 @@ where
     P: Payload,
 {
     type Payload = P;
-}
 
-impl<P> AsRef<P> for JsonRequest<P> {
-    fn as_ref(&self) -> &P {
-        &self.payload
-    }
-}
-
-impl<P> AsMut<P> for JsonRequest<P> {
-    fn as_mut(&mut self) -> &mut P {
+    fn payload_mut(&mut self) -> &mut Self::Payload {
         &mut self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        &self.payload
     }
 }
 
@@ -73,13 +69,13 @@ impl<P: Payload + Serialize> core::ops::Deref for JsonRequest<P> {
     type Target = P;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        self.payload_ref()
     }
 }
 
 impl<P: Payload + Serialize> core::ops::DerefMut for JsonRequest<P> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut()
+        self.payload_mut()
     }
 }
 

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -9,11 +9,13 @@ pub use self::{has_payload::HasPayload, payload::Payload, request::Request};
 mod all;
 mod json;
 mod multipart;
+mod requester;
 mod utils;
 
 pub use all::*;
 pub use json::JsonRequest;
 pub use multipart::MultipartRequest;
+pub use requester::Requester;
 
 /// A type that is returned after making a request to Telegram.
 pub type ResponseResult<T> = Result<T, crate::RequestError>;

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -10,12 +10,14 @@ mod all;
 mod json;
 mod multipart;
 mod requester;
+mod requester_ext;
 mod utils;
 
 pub use all::*;
 pub use json::JsonRequest;
 pub use multipart::MultipartRequest;
 pub use requester::Requester;
+pub use requester_ext::RequesterExt;
 
 /// A type that is returned after making a request to Telegram.
 pub type ResponseResult<T> = Result<T, crate::RequestError>;

--- a/src/requests/multipart.rs
+++ b/src/requests/multipart.rs
@@ -55,17 +55,13 @@ where
     P: Payload,
 {
     type Payload = P;
-}
 
-impl<P> AsRef<P> for MultipartRequest<P> {
-    fn as_ref(&self) -> &P {
-        &self.payload
-    }
-}
-
-impl<P> AsMut<P> for MultipartRequest<P> {
-    fn as_mut(&mut self) -> &mut P {
+    fn payload_mut(&mut self) -> &mut Self::Payload {
         &mut self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        &self.payload
     }
 }
 
@@ -78,7 +74,7 @@ where
     type Target = P;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        self.payload_ref()
     }
 }
 
@@ -89,7 +85,7 @@ where
     P::Output: DeserializeOwned,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut()
+        self.payload_mut()
     }
 }
 

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -6,7 +6,7 @@
 /// This trait provides some additional information needed for sending request
 /// to the telegram.
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
-pub trait Payload: AsMut<Self> + AsRef<Self> {
+pub trait Payload {
     /// Return type of the telegram method.
     ///
     /// Note: that should not include result wrappers (e.g. it should be simply

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -12,7 +12,7 @@ pub trait Request: HasPayload {
      */
 
     /// Type of error that may happen during sending the request to telegram.
-    type Err;
+    type Err: std::error::Error;
 
     /// Type of future returned by [`send`](Request::send) method.
     type Send: Future<Output = Result<Output<Self>, Self::Err>>;

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -1,0 +1,15 @@
+use crate::{payloads::GetMe, requests::Request};
+
+/// The trait implemented by all bots & bot wrappers.
+/// Essentially a request builder factory (?).
+///
+/// _This trait is included in the crate's [`prelude`](crate::prelude)_.
+#[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
+pub trait Requester {
+    type GetMe: Request<Payload = GetMe>;
+
+    /// For telegram documentation of the method see [`GetMe`].
+    fn get_me(&self) -> Self::GetMe;
+
+    // FIXME(waffle): add remaining 69 methods
+}

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -1,0 +1,18 @@
+use crate::{bot::CacheMe, requests::Requester};
+
+pub trait RequesterExt: Requester {
+    /// Add `get_me` caching ability, see [`CacheMe`] for more.
+    fn cache_me(self) -> CacheMe<Self>
+    where
+        Self: Sized,
+    {
+        CacheMe::new(self)
+    }
+}
+
+impl<T> RequesterExt for T
+where
+    T: Requester,
+{
+    /* use default impls */
+}


### PR DESCRIPTION
- remove `AsMut`/`AsRef` bounds because of a compiler bug
- add `Requester` trait and `GetMe` payload
- implement `get_me` caching
- add `:std::error::Error` bound on `Request::Err`

Closes https://github.com/teloxide/teloxide/issues/278