### PR TITLE
Request throttling (limits)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ mime = "0.3.16"
 thiserror = "1.0.20"
 once_cell = "1.4.0"
 
+# FIXME(waffle): use crates.io once published
+vecrem = { git = "https://github.com/WaffleLapkin/vecrem" }
+
 [features]
 # features those require nightly compiler
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 
 [dependencies]
 futures = "0.3.5"
-tokio = { version = "0.2.21", features = ["fs", "stream", "full"] }
+tokio = { version = "0.2.21", features = ["fs", "stream"] }
 tokio-util = "0.3.1"
 pin-project = "0.4.23"
 bytes = "0.5.5"
@@ -33,6 +33,7 @@ derive_more = "0.99.9"
 mime = "0.3.16"
 thiserror = "1.0.20"
 once_cell = "1.4.0"
+never = "0.1.0"
 
 # FIXME(waffle): use crates.io once published
 vecrem = { git = "https://github.com/WaffleLapkin/vecrem", rev = "6b9b6f42342df8b75548c6ed387072ff235429b1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 
 [dependencies]
 futures = "0.3.5"
-tokio = { version = "0.2.21", features = ["fs", "stream"] }
+tokio = { version = "0.2.21", features = ["fs", "stream", "full"] }
 tokio-util = "0.3.1"
 pin-project = "0.4.23"
 bytes = "0.5.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0.20"
 once_cell = "1.4.0"
 
 # FIXME(waffle): use crates.io once published
-vecrem = { git = "https://github.com/WaffleLapkin/vecrem" }
+vecrem = { git = "https://github.com/WaffleLapkin/vecrem", rev = "6b9b6f42342df8b75548c6ed387072ff235429b1" }
 
 [features]
 # features those require nightly compiler

--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -1716,7 +1716,7 @@ impl Requester for Bot {
     fn send_message<C, T>(&self, chat_id: C, text: T) -> JsonRequest<payloads::SendMessage>
     where
         C: Into<ChatId>,
-        T: Into<String>
+        T: Into<String>,
     {
         Self::SendMessage::new(self.clone(), payloads::SendMessage::new(chat_id, text))
     }

--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -1710,4 +1710,14 @@ impl Requester for Bot {
     fn get_me(&self) -> JsonRequest<payloads::GetMe> {
         Self::GetMe::new(self.clone(), payloads::GetMe::new())
     }
+
+    type SendMessage = JsonRequest<payloads::SendMessage>;
+
+    fn send_message<C, T>(&self, chat_id: C, text: T) -> JsonRequest<payloads::SendMessage>
+    where
+        C: Into<ChatId>,
+        T: Into<String>
+    {
+        Self::SendMessage::new(self.clone(), payloads::SendMessage::new(chat_id, text))
+    }
 }

--- a/src/bot/auto_send.rs
+++ b/src/bot/auto_send.rs
@@ -6,7 +6,10 @@ use std::{
 
 use futures::future::FusedFuture;
 
-use crate::requests::{HasPayload, Output, Request, Requester};
+use crate::{
+    requests::{HasPayload, Output, Request, Requester},
+    types::ChatId,
+};
 
 /// Send requests automatically.
 ///
@@ -64,6 +67,16 @@ impl<B: Requester> Requester for AutoSend<B> {
 
     fn get_me(&self) -> Self::GetMe {
         AutoRequest::new(self.bot.get_me())
+    }
+
+    type SendMessage = AutoRequest<B::SendMessage>;
+
+    fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
+    where
+        C: Into<ChatId>,
+        T: Into<String>,
+    {
+        AutoRequest::new(self.bot.send_message(chat_id, text))
     }
 }
 

--- a/src/bot/cache_me.rs
+++ b/src/bot/cache_me.rs
@@ -13,6 +13,8 @@ use crate::{
     requests::{HasPayload, Request, Requester},
     types::User,
 };
+use crate::payloads::SendMessage;
+use crate::types::ChatId;
 
 /// `get_me` cache.
 ///
@@ -65,6 +67,16 @@ impl<B: Requester> Requester for CacheMe<B> {
                 GetMe::new(),
             ),
         }
+    }
+
+    type SendMessage = B::SendMessage;
+
+    fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
+    where
+        C: Into<ChatId>,
+        T: Into<String>
+    {
+        self.bot.send_message(chat_id, text)
     }
 }
 

--- a/src/bot/cache_me.rs
+++ b/src/bot/cache_me.rs
@@ -11,10 +11,8 @@ use once_cell::sync::OnceCell;
 use crate::{
     payloads::GetMe,
     requests::{HasPayload, Request, Requester},
-    types::User,
+    types::{ChatId, User},
 };
-use crate::payloads::SendMessage;
-use crate::types::ChatId;
 
 /// `get_me` cache.
 ///
@@ -74,7 +72,7 @@ impl<B: Requester> Requester for CacheMe<B> {
     fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
     where
         C: Into<ChatId>,
-        T: Into<String>
+        T: Into<String>,
     {
         self.bot.send_message(chat_id, text)
     }

--- a/src/bot/limits.rs
+++ b/src/bot/limits.rs
@@ -1,30 +1,35 @@
-use crate::Bot;
-use std::collections::{VecDeque, HashMap};
-use std::time::Instant;
-use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc};
-use std::cmp::max;
-use crate::requests::{Requester, Request, Output, HasPayload, Payload};
-use crate::payloads::{GetMe, SendMessage};
-use crate::types::ChatId;
-use tokio::sync::oneshot::{Sender, Receiver, channel};
-use std::future::Future;
-use futures::task::{Context, Poll};
-use pin_project::__private::Pin;
-use core::time::Duration;
-use futures::{TryFutureExt, StreamExt, FutureExt};
-use tokio::time::{delay_until, delay_for};
-use futures::stream::FuturesUnordered;
-use futures::executor::block_on;
-use futures::future::join3;
-use futures::future::ready;
+use std::{
+    collections::{hash_map::Entry, HashMap, VecDeque},
+    future::Future,
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
-// FIXME: rename to Throttle
+use futures::task::{Context, Poll};
+use tokio::{
+    sync::{
+        mpsc,
+        oneshot::{channel, Receiver, Sender},
+    },
+    time::delay_for,
+};
+use vecrem::VecExt;
+
+use crate::{
+    bot::limits::chan_send::{ChanSend, SendTy},
+    payloads::SendMessage,
+    requests::{HasPayload, Output, Request, Requester},
+    types::ChatId,
+};
 
 const MINUTE: Duration = Duration::from_secs(50); // FIXME: min = sec * 10 only in tests
 const SECOND: Duration = Duration::from_secs(1);
 const DELAY: Duration = Duration::from_millis(250); // second/4
 
+/// Telegram request limits.
+///
+/// This struct is used in [`Throttle`]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Limits {
     /// Allowed messages in one chat per second
     pub chat_s: u32,
@@ -34,26 +39,21 @@ pub struct Limits {
     pub chat_m: u32,
 }
 
-// https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
+/// Defaults are taken from [telegram documentation][tgdoc].
+///
+/// [tgdoc]: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
 impl Default for Limits {
     fn default() -> Self {
-        Self {
-            chat_s: 1,
-            overall_s: 30,
-            chat_m: 20,
-        }
+        Self { chat_s: 1, overall_s: 30, chat_m: 20 }
     }
 }
 
-pub struct Limited<B> {
+pub struct Throttle<B> {
     bot: B,
     queue: mpsc::Sender<(ChatId, Sender<()>)>,
 }
 
-async fn worker(
-    limits: Limits,
-    mut queue_rx: mpsc::Receiver<(ChatId, Sender<()>)>,
-) {
+async fn worker(limits: Limits, mut queue_rx: mpsc::Receiver<(ChatId, Sender<()>)>) {
     // FIXME: use spawn_blocking?
 
     // FIXME: remove unnecessary ChatId clones
@@ -88,19 +88,26 @@ async fn worker(
         // make history and hchats up-to-date
         while let Some((_, time)) = history.front() {
             // history is sorted, we found first up-to-date thing
-            if time >= &min_back { break; }
+            if time >= &min_back {
+                break;
+            }
 
             if let Some((chat, _)) = history.pop_front() {
-                if let Entry::Occupied(entry) = hchats
-                    .entry(chat)
-                    .and_modify(|count| { *count -= 1; }) {
-                    if *entry.get() == 0 { entry.remove_entry(); }
+                if let Entry::Occupied(entry) = hchats.entry(chat).and_modify(|count| {
+                    *count -= 1;
+                }) {
+                    if *entry.get() == 0 {
+                        entry.remove_entry();
+                    }
                 }
             }
         }
 
-        // as truncates which is ok since in case of truncation it would always be >= limits.overall_s
-        let mut allowed = limits.overall_s.saturating_sub(history.iter().take_while(|(_, time)| time > &sec_back).count() as u32);
+        // as truncates which is ok since in case of truncation it would always be >=
+        // limits.overall_s
+        let mut allowed = limits
+            .overall_s
+            .saturating_sub(history.iter().take_while(|(_, time)| time > &sec_back).count() as u32);
 
         if allowed == 0 {
             hchats_s.clear();
@@ -109,23 +116,15 @@ async fn worker(
         }
 
         for (chat, _) in history.iter().take_while(|(_, time)| time > &sec_back) {
-            *hchats_s
-                .entry(chat.clone())
-                .or_insert(0) += 1;
+            *hchats_s.entry(chat.clone()).or_insert(0) += 1;
         }
 
         let mut queue_rem = queue.removing();
         while let Some(entry) = queue_rem.next() {
             let chat = &entry.value().0;
             let cond = {
-                hchats_s
-                    .get(chat)
-                    .copied()
-                    .unwrap_or(0) < limits.chat_s &&
-                    hchats
-                        .get(chat)
-                        .copied()
-                        .unwrap_or(0) < limits.chat_m
+                hchats_s.get(chat).copied().unwrap_or(0) < limits.chat_s
+                    && hchats.get(chat).copied().unwrap_or(0) < limits.chat_m
             };
 
             if cond {
@@ -151,37 +150,70 @@ async fn worker(
     }
 }
 
-impl<B> Limited<B> {
+impl<B> Throttle<B> {
+    /// Creates new [`Throttle`] alongside with worker future.
+    ///
+    /// Note: [`Throttle`] will only send requests if returned worker is
+    /// polled/spawned/awaited.
     pub fn new(bot: B, limits: Limits) -> (Self, impl Future<Output = ()>) {
         // FIXME: just a random number, currently
         let (queue_tx, queue_rx) = mpsc::channel(130);
 
-        let worker = worker(
-            limits,
-            queue_rx,
-        );
+        let worker = worker(limits, queue_rx);
 
-        let this = Self { bot, queue: queue_tx, };
+        let this = Self { bot, queue: queue_tx };
 
         (this, worker)
     }
+
+    /// Creates new [`Throttle`] spawning the worker with `tokio::spawn`
+    ///
+    /// Note: it's recommended to use [`RequesterExt::throttle`] instead.
+    pub fn new_spawn(bot: B, limits: Limits) -> Self
+    where
+        // Basically, I hate this bound.
+        // This is yet another problem caused by [rust-lang/#76882].
+        // And I think it *is* a bug.
+        //
+        // [rust-lang/#76882]: https://github.com/rust-lang/rust/issues/76882
+        //
+        // Though crucially I can't think of a case with non-static bot.
+        // But anyway, it doesn't change the fact that this bound is redundant.
+        //
+        // (waffle)
+        B: 'static,
+    {
+        let (this, worker) = Self::new(bot, limits);
+        tokio::spawn(worker);
+        this
+    }
+
+    /// Allows to access inner bot
+    pub fn inner(&self) -> &B {
+        &self.bot
+    }
+
+    /// Unwraps inner bot
+    pub fn into_inner(self) -> B {
+        self.bot
+    }
 }
 
-impl<B: Requester> Requester for Limited<B> {
+impl<B: Requester> Requester for Throttle<B> {
     type GetMe = B::GetMe;
 
     fn get_me(&self) -> Self::GetMe {
         self.bot.get_me()
     }
 
-    type SendMessage = LimitedRequest<B::SendMessage>;
+    type SendMessage = ThrottlingRequest<B::SendMessage>;
 
     fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
     where
         C: Into<ChatId>,
-        T: Into<String>
+        T: Into<String>,
     {
-        LimitedRequest(self.bot.send_message(chat_id, text), self.queue.clone())
+        ThrottlingRequest(self.bot.send_message(chat_id, text), self.queue.clone())
     }
 }
 
@@ -196,9 +228,9 @@ impl GetChatId for SendMessage {
     }
 }
 
-pub struct LimitedRequest<R>(R, mpsc::Sender<(ChatId, Sender<()>)>);
+pub struct ThrottlingRequest<R>(R, mpsc::Sender<(ChatId, Sender<()>)>);
 
-impl<R: HasPayload> HasPayload for LimitedRequest<R> {
+impl<R: HasPayload> HasPayload for ThrottlingRequest<R> {
     type Payload = R::Payload;
 
     fn payload_mut(&mut self) -> &mut Self::Payload {
@@ -210,7 +242,7 @@ impl<R: HasPayload> HasPayload for LimitedRequest<R> {
     }
 }
 
-impl<R: Request> Request for LimitedRequest<R>
+impl<R: Request> Request for ThrottlingRequest<R>
 where
     <R as HasPayload>::Payload: GetChatId,
 {
@@ -218,14 +250,10 @@ where
     type Send = LimitedSend<R>;
     type SendRef = LimitedSend<R>;
 
-    fn send(mut self) -> Self::Send {
+    fn send(self) -> Self::Send {
         let (tx, rx) = channel();
         let send = self.1.send_t((self.0.payload_ref().get_chat_id().clone(), tx));
-        LimitedSend::Registering {
-            request: self.0,
-            send,
-            wait: rx,
-        }
+        LimitedSend::Registering { request: self.0, send, wait: rx }
     }
 
     fn send_ref(&self) -> Self::SendRef {
@@ -263,7 +291,9 @@ impl<R: Request> Future for LimitedSend<R> {
                 Poll::Ready(r) => {
                     // FIXME(waffle): remove unwrap
                     r.unwrap();
-                    if let SendRepl::Registering { request, send: _, wait } = self.as_mut().project_replace(LimitedSend::Done) {
+                    if let SendRepl::Registering { request, send: _, wait } =
+                        self.as_mut().project_replace(LimitedSend::Done)
+                    {
                         self.as_mut().project_replace(LimitedSend::Pending { request, wait });
                     }
 
@@ -275,7 +305,9 @@ impl<R: Request> Future for LimitedSend<R> {
                 Poll::Ready(r) => {
                     // FIXME(waffle): remove unwrap
                     r.unwrap();
-                    if let SendRepl::Pending { request, wait: _ } = self.as_mut().project_replace(LimitedSend::Done) {
+                    if let SendRepl::Pending { request, wait: _ } =
+                        self.as_mut().project_replace(LimitedSend::Done)
+                    {
                         self.as_mut().project_replace(LimitedSend::Sent { fut: request.send() });
                     }
 
@@ -292,27 +324,19 @@ impl<R: Request> Future for LimitedSend<R> {
     }
 }
 
-use chan_send::{ChanSend, SendTy as _};
-use crate::bot::limits::chan_send::SendTy;
-use std::collections::hash_map::Entry;
-use core::mem;
-use vecrem::VecExt;
-
 mod chan_send {
-    use tokio::sync::mpsc;
     use crate::types::ChatId;
-    use tokio::sync::oneshot::Sender;
-    use std::future::Future;
     use futures::task::{Context, Poll};
     use pin_project::__private::Pin;
-    use tokio::sync::mpsc::error::SendError;
+    use std::future::Future;
+    use tokio::sync::{mpsc, mpsc::error::SendError, oneshot::Sender};
 
     pub(crate) trait SendTy {
         fn send_t(self, val: (ChatId, Sender<()>)) -> ChanSend;
     }
 
     #[pin_project::pin_project]
-    pub/*(crate) */struct ChanSend(#[pin] Inner); // FIXME
+    pub struct ChanSend(#[pin] Inner); // FIXME
 
     #[cfg(not(feature = "nightly"))]
     type Inner = Pin<Box<dyn Future<Output = Result<(), SendError<(ChatId, Sender<()>)>>>>>;
@@ -323,7 +347,10 @@ mod chan_send {
         fn send_t(mut self, val: (ChatId, Sender<()>)) -> ChanSend {
             #[cfg(feature = "nightly")]
             {
-                fn def(mut sender: mpsc::Sender<(ChatId, Sender<()>)>, val: (ChatId, Sender<()>)) -> Inner {
+                fn def(
+                    mut sender: mpsc::Sender<(ChatId, Sender<()>)>,
+                    val: (ChatId, Sender<()>),
+                ) -> Inner {
                     async move { sender.send(val).await }
                 }
                 return ChanSend(def(self, val));
@@ -340,5 +367,4 @@ mod chan_send {
             self.project().0.poll(cx)
         }
     }
-
 }

--- a/src/bot/limits.rs
+++ b/src/bot/limits.rs
@@ -1,0 +1,279 @@
+use crate::Bot;
+use std::collections::{VecDeque, HashMap};
+use std::time::Instant;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use std::cmp::max;
+use crate::requests::{Requester, Request, Output, HasPayload, Payload};
+use crate::payloads::{GetMe, SendMessage};
+use crate::types::ChatId;
+use tokio::sync::oneshot::{Sender, Receiver, channel};
+use std::future::Future;
+use futures::task::{Context, Poll};
+use pin_project::__private::Pin;
+use core::time::Duration;
+use futures::{TryFutureExt, StreamExt, FutureExt};
+use tokio::time::{delay_until, delay_for};
+use futures::stream::FuturesUnordered;
+use futures::executor::block_on;
+use futures::future::join3;
+
+const MINUTE: Duration = Duration::from_secs(10);
+const SECOND: Duration = Duration::from_secs(1);
+const DELAY: Duration = Duration::from_millis(250); // second/4
+
+pub struct Limits {
+    /// Allowed messages in one chat per second
+    pub chat_s: u32,
+    /// Allowed messages per second
+    pub overall_s: u32,
+    /// Allowed messages in one chat per minute
+    pub chat_m: u32,
+}
+
+// https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            chat_s: 1,
+            overall_s: 30,
+            chat_m: 20,
+        }
+    }
+}
+
+pub struct Limited<B> {
+    // Some fields are probably only needed by the worker
+    //limits: Limits,
+    bot: B,
+    queue: Arc<Mutex<VecDeque<(ChatId, Sender<()>)>>>, // FIXME: struct with fast remove and add
+    history: Arc<Mutex<VecDeque<(ChatId, Instant)>>>,
+    hchats:  Arc<Mutex<HashMap<ChatId, u32>>>,
+}
+
+async fn worker(
+    limits: Limits,
+    queue: Arc<Mutex<VecDeque<(ChatId, Sender<()>)>>>,
+    history: Arc<Mutex<VecDeque<(ChatId, Instant)>>>,
+    hchats:  Arc<Mutex<HashMap<ChatId, u32>>>,
+) {
+    // FIXME: remove unnecessary ChatId clones
+    loop {
+        println!("1");
+        let mut history = history.lock().await;
+        let mut hchats = hchats.lock().await;
+        let mut queue = queue.lock().await;
+
+        let now = dbg!(Instant::now());
+        let min_back = now - MINUTE;
+        let sec_back = now - SECOND;
+
+        println!("2");
+
+        // make history and hchats up-to-date
+        while let Some((_, time)) = history.front() {
+            // history is sorted, we found first up-to-date thing
+            if time >= &min_back { break; }
+
+            if let Some((chat, _)) = history.pop_front() {
+                hchats
+                    .entry(chat)
+                    .and_modify(|count| { *count -= 1; }); // TODO: remove entries with count == 0
+            }
+        }
+
+        // as truncates which is ok since in case of truncation it would always be >= limits.overall_s
+        let mut allowed = limits.overall_s.saturating_sub(dbg!(&history).iter().take_while(|(_, time)| time > &sec_back).count() as u32);
+
+        if allowed == 0 {
+            delay_for(DELAY).await;
+            continue;
+        }
+
+        println!("3");
+
+        let mut hchats_s = HashMap::new();
+        for (chat, _) in history.iter().take_while(|(_, time)| time > &sec_back) {
+            *hchats_s
+                .entry(chat.clone())
+                .or_insert(0) += 1;
+        }
+
+
+        dbg!(&hchats_s);
+        dbg!(&hchats);
+
+        dbg!(allowed);
+
+        let mut i = 0;
+        while allowed > 0 && i < queue.len() {
+            let chat = &queue[i].0;
+
+            if dbg!(hchats_s
+                .get(chat)
+                .copied()
+                .unwrap_or(0) < limits.chat_s) &&
+                dbg!(hchats
+                    .get(chat)
+                    .copied()
+                    .unwrap_or(0) < limits.chat_m)
+            {
+                let chat = chat.clone();
+                *hchats_s.entry(chat.clone()).or_insert(0) += 1;
+                *hchats.entry(chat.clone()).or_insert(0) += 1;
+
+                println!("worker send");
+                dbg!(&hchats_s);
+                dbg!(&hchats);
+                history.push_back((chat, Instant::now()));
+                queue.remove(i).unwrap().1.send(());
+                allowed -= 1;
+                dbg!(allowed);
+            } else {
+                i += 1;
+            }
+        }
+
+        delay_for(DELAY).await;
+    }
+}
+
+impl<B> Limited<B> {
+    pub fn new(bot: B, limits: Limits) -> (Self, impl Future<Output = ()>) {
+        let history = Arc::new(Mutex::new(VecDeque::with_capacity(
+            max(limits.chat_s, max(limits.overall_s, limits.chat_m)) as _
+        )));
+
+        let queue = Arc::new(Mutex::new(VecDeque::new()));
+        let hchats = Arc::new(Mutex::new(HashMap::new()));
+
+        let worker = worker(
+            limits,
+            Arc::clone(&queue),
+            Arc::clone(&history),
+            Arc::clone(&hchats),
+        );
+
+        let this = Self {
+            //limits,
+            bot,
+            history,
+            queue,
+            hchats,
+        };
+
+        (this, worker)
+    }
+}
+
+impl<B: Requester> Requester for Limited<B> {
+    type GetMe = B::GetMe;
+
+    fn get_me(&self) -> Self::GetMe {
+        self.bot.get_me()
+    }
+
+    type SendMessage = LimitedRequest<B::SendMessage>;
+
+    fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
+    where
+        C: Into<ChatId>,
+        T: Into<String>
+    {
+        LimitedRequest(self.bot.send_message(chat_id, text), Arc::clone(&self.queue))
+    }
+}
+
+pub trait GetChatId {
+    // FIXME(waffle): add note about false negatives with ChatId::Username
+    fn get_chat_id(&self) -> &ChatId;
+}
+
+impl GetChatId for SendMessage {
+    fn get_chat_id(&self) -> &ChatId {
+        &self.chat_id
+    }
+}
+
+pub struct LimitedRequest<R>(R, Arc<Mutex<VecDeque<(ChatId, Sender<()>)>>>);
+
+impl<R: HasPayload> HasPayload for LimitedRequest<R> {
+    type Payload = R::Payload;
+
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        self.0.payload_mut()
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
+        self.0.payload_ref()
+    }
+}
+
+impl<R: Request> Request for LimitedRequest<R>
+where
+    <R as HasPayload>::Payload: GetChatId,
+{
+    type Err = R::Err;
+    type Send = LimitedSend<R>;
+    type SendRef = LimitedSend<R>;
+
+    fn send(self) -> Self::Send {
+        let (tx, rx) = channel();
+        // FIXME
+        let mut g = block_on(self.1.lock());
+        g.push_back((self.0.payload_ref().get_chat_id().clone(), tx));
+        LimitedSend::Pending {
+            request: self.0,
+            wait: rx,
+        }
+    }
+
+    fn send_ref(&self) -> Self::SendRef {
+        unimplemented!()
+    }
+}
+
+#[pin_project::pin_project(project = SendProj, project_replace = SendRepl)]
+pub enum LimitedSend<R: Request> {
+    Pending {
+        request: R,
+        #[pin]
+        wait: Receiver<()>,
+    },
+    Sent {
+        #[pin]
+        fut: R::Send,
+    },
+    Done,
+}
+
+impl<R: Request> Future for LimitedSend<R> {
+    type Output = Result<Output<R>, R::Err>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        println!("poll");
+        match self.as_mut().project() {
+            SendProj::Pending { request: _, wait } => match wait.poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(r) => {
+                    println!("pending-ready");
+                    // FIXME(waffle): remove unwrap
+                    r.unwrap();
+                    if let SendRepl::Pending { request, wait: _ } = self.as_mut().project_replace(LimitedSend::Done) {
+                        self.as_mut().project_replace(LimitedSend::Sent { fut: request.send() });
+                    }
+
+                    self.poll(cx)
+                }
+            },
+            SendProj::Sent { fut } => {
+                println!("sent");
+                let res = futures::ready!(fut.poll(cx));
+                println!("sent-ready");
+                self.set(LimitedSend::Done);
+                Poll::Ready(res)
+            }
+            SendProj::Done => Poll::Pending,
+        }
+    }
+}

--- a/src/bot/limits.rs
+++ b/src/bot/limits.rs
@@ -122,7 +122,7 @@ impl Default for Limits {
 ///
 /// ## Examples
 ///
-/// ```no_run (throttle fails to spawn task without tokio runtime) 
+/// ```no_run (throttle fails to spawn task without tokio runtime)
 /// use teloxide_core::{bot::Limits, requests::RequesterExt, Bot};
 ///
 /// # #[allow(deprecated)]

--- a/src/bot/limits.rs
+++ b/src/bot/limits.rs
@@ -122,9 +122,10 @@ impl Default for Limits {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```no_run (throttle fails to spawn task without tokio runtime) 
 /// use teloxide_core::{bot::Limits, requests::RequesterExt, Bot};
 ///
+/// # #[allow(deprecated)]
 /// let bot = Bot::new("TOKEN").throttle(Limits::default());
 ///
 /// /* send many requests here */

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -21,6 +21,7 @@ mod limits;
 
 pub use auto_send::AutoSend;
 pub use cache_me::CacheMe;
+pub use limits::{Limits, Throttle};
 
 pub(crate) const TELOXIDE_TOKEN: &str = "TELOXIDE_TOKEN";
 pub(crate) const TELOXIDE_PROXY: &str = "TELOXIDE_PROXY";

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -17,6 +17,7 @@ mod api;
 mod auto_send;
 mod cache_me;
 mod download;
+mod limits;
 
 pub use auto_send::AutoSend;
 pub use cache_me::CacheMe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,11 @@ pub mod prelude;
 pub mod requests;
 pub mod types;
 
+// FIXME(waffle): made `pub` to reexport bot wrappers, in future we may want to
+//                reexport them from elsewhere
+pub mod bot;
+
 // reexported
-mod bot;
 mod errors;
 
 // implementation details

--- a/src/payloads/mod.rs
+++ b/src/payloads/mod.rs
@@ -1,5 +1,7 @@
 pub mod setters;
 
 mod get_me;
+mod send_message;
 
 pub use get_me::{GetMe, GetMeSetters};
+pub use send_message::{SendMessage, SendMessageSetters};

--- a/src/payloads/send_message.rs
+++ b/src/payloads/send_message.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     requests::{HasPayload, Payload},
-    types::{ChatId, Message, ParseMode, ReplyMarkup}
+    types::{ChatId, Message, ParseMode, ReplyMarkup},
 };
 
 /// Use this method to send text messages.

--- a/src/payloads/send_message.rs
+++ b/src/payloads/send_message.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    requests::{HasPayload, Payload},
+    types::{ChatId, Message, ParseMode, ReplyMarkup}
+};
+
+/// Use this method to send text messages.
+///
+/// On success, the sent [`Message`] is returned.
+///
+/// [`Message`]: crate::types::Message
+#[serde_with_macros::skip_serializing_none]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
+pub struct SendMessage {
+    ///	Unique identifier for the target chat or username of the target channel
+    /// (in the format `@channelusername`)
+    pub chat_id: ChatId,
+    /// Text of the message to be sent
+    pub text: String,
+    /// Send [Markdown] or [HTML], if you want Telegram apps to show
+    /// [bold, italic, fixed-width text or inline URLs] in your bot's message.
+    ///
+    /// [Markdown]: crate::types::ParseMode::Markdown
+    /// [HTML]: crate::types::ParseMode::HTML
+    /// [bold, italic, fixed-width text or inline URLs]:
+    /// crate::types::ParseMode
+    pub parse_mode: Option<ParseMode>,
+    /// Disables link previews for links in this message
+    pub disable_web_page_preview: Option<bool>,
+    /// Sends the message silently.
+    /// Users will receive a notification with no sound.
+    pub disable_notification: Option<bool>,
+    /// If the message is a reply, [id] of the original message
+    ///
+    /// [id]: crate::types::Message::id
+    pub reply_to_message_id: Option<i32>,
+    /// Additional interface options.
+    pub reply_markup: Option<ReplyMarkup>,
+}
+
+impl Payload for SendMessage {
+    type Output = Message;
+
+    const NAME: &'static str = "sendMessage";
+}
+
+impl SendMessage {
+    pub fn new<C, T>(chat_id: C, text: T) -> Self
+    where
+        C: Into<ChatId>,
+        T: Into<String>,
+    {
+        SendMessage {
+            chat_id: chat_id.into(),
+            text: text.into(),
+            parse_mode: None,
+            disable_web_page_preview: None,
+            disable_notification: None,
+            reply_to_message_id: None,
+            reply_markup: None,
+        }
+    }
+}
+
+pub trait SendMessageSetters: HasPayload<Payload = SendMessage> + Sized {
+    fn chat_id<T>(mut self, value: T) -> Self
+    where
+        T: Into<ChatId>,
+    {
+        self.payload_mut().chat_id = value.into();
+        self
+    }
+
+    fn text<T>(mut self, value: T) -> Self
+    where
+        T: Into<String>, // TODO: into?
+    {
+        self.payload_mut().text = value.into();
+        self
+    }
+
+    fn parse_mode(mut self, value: ParseMode) -> Self {
+        self.payload_mut().parse_mode = Some(value);
+        self
+    }
+
+    fn disable_web_page_preview(mut self, value: bool) -> Self {
+        self.payload_mut().disable_web_page_preview = Some(value);
+        self
+    }
+
+    fn disable_notification(mut self, value: bool) -> Self {
+        self.payload_mut().disable_notification = Some(value);
+        self
+    }
+
+    fn reply_to_message_id(mut self, value: i32) -> Self {
+        self.payload_mut().reply_to_message_id = Some(value);
+        self
+    }
+
+    fn reply_markup<T>(mut self, value: T) -> Self
+    where
+        T: Into<ReplyMarkup>,
+    {
+        self.payload_mut().reply_markup = Some(value.into());
+        self
+    }
+}
+
+impl<P> SendMessageSetters for P where P: HasPayload<Payload = SendMessage> {}

--- a/src/payloads/setters.rs
+++ b/src/payloads/setters.rs
@@ -1,2 +1,1 @@
-pub use crate::payloads::GetMeSetters as _;
-pub use crate::payloads::SendMessageSetters as _;
+pub use crate::payloads::{GetMeSetters as _, SendMessageSetters as _};

--- a/src/payloads/setters.rs
+++ b/src/payloads/setters.rs
@@ -1,1 +1,2 @@
 pub use crate::payloads::GetMeSetters as _;
+pub use crate::payloads::SendMessageSetters as _;

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use crate::requests::{HasPayload, Output};
 
 /// A ready-to-send telegram request.
-///
 // FIXME(waffle): Write better doc for the trait
 ///
 /// ## Implementation notes

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -3,7 +3,18 @@ use std::future::Future;
 use crate::requests::{HasPayload, Output};
 
 /// A ready-to-send telegram request.
+///
 // FIXME(waffle): Write better doc for the trait
+///
+/// ## Implementation notes
+///
+/// It is not recommended to do any kind of _work_ in `send` or `send_ref`.
+/// Instead it's recommended to do all the (possible) stuff in the returned
+/// future. In other words — keep it lazy.
+///
+/// This is crucial for request wrappers which may want to cancel and/or never
+/// send the underlying request. E.g.: [`Throttle<B>`]'s `send_ref` calls
+/// `B::send_ref` while _not_ meaning to really send the request right now.
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
 pub trait Request: HasPayload {
     /*

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -1,8 +1,5 @@
 use crate::{
-    payloads::{
-        GetMe,
-        SendMessage
-    },
+    payloads::{GetMe, SendMessage},
     requests::Request,
     types::ChatId,
 };

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -1,4 +1,11 @@
-use crate::{payloads::GetMe, requests::Request};
+use crate::{
+    payloads::{
+        GetMe,
+        SendMessage
+    },
+    requests::Request,
+    types::ChatId,
+};
 
 /// The trait implemented by all bots & bot wrappers.
 /// Essentially a request builder factory (?).
@@ -11,5 +18,13 @@ pub trait Requester {
     /// For telegram documentation of the method see [`GetMe`].
     fn get_me(&self) -> Self::GetMe;
 
-    // FIXME(waffle): add remaining 69 methods
+    type SendMessage: Request<Payload = SendMessage>;
+
+    /// For telegram documentation of the method see [`SendMessage`].
+    fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage
+    where
+        C: Into<ChatId>,
+        T: Into<String>;
+
+    // FIXME(waffle): add remaining 68 methods
 }

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -1,4 +1,8 @@
-use crate::{requests::Requester, AutoSend, CacheMe};
+use crate::{
+    bot::{CacheMe, Limits, Throttle},
+    requests::Requester,
+    AutoSend,
+};
 
 pub trait RequesterExt: Requester {
     /// Add `get_me` caching ability, see [`CacheMe`] for more.
@@ -15,6 +19,19 @@ pub trait RequesterExt: Requester {
         Self: Sized,
     {
         AutoSend::new(self)
+    }
+
+    /// Add throttling ability, see [`Throttle`] for more.
+    ///
+    /// Note: this spawns the worker, just as [`Throttle::new_spawn`].
+    fn throttle(self, limits: Limits) -> Throttle<Self>
+    where
+        Self: Sized,
+        // >:(
+        // (waffle)
+        Self: 'static,
+    {
+        Throttle::new_spawn(self, limits)
     }
 }
 


### PR DESCRIPTION
This adds `Throttling` bot adaptor which can automatically throttle when telegram limits are exceeded.

Also adds `send_message` to `Requestor`.

Resolves teloxide/teloxide#164