### PR TITLE
Resolve fixme(waffle): use As{Mut,Ref} for payloads again

### DIFF
--- a/src/adaptors/auto_send.rs
+++ b/src/adaptors/auto_send.rs
@@ -164,18 +164,31 @@ where
     }
 }
 
-impl<R: Request> HasPayload for AutoRequest<R> {
+impl<R> HasPayload for AutoRequest<R>
+where
+    R: Request,
+{
     type Payload = R::Payload;
+}
 
-    fn payload_mut(&mut self) -> &mut Self::Payload {
+impl<R> AsMut<R::Payload> for AutoRequest<R>
+where
+    R: Request,
+{
+    fn as_mut(&mut self) -> &mut R::Payload {
         match &mut self.0 {
             Inner::Request(req) => req.payload_mut(),
             Inner::Future(_) => already_polled(),
             Inner::Done => done_unreachable(),
         }
     }
+}
 
-    fn payload_ref(&self) -> &Self::Payload {
+impl<R> AsRef<R::Payload> for AutoRequest<R>
+where
+    R: Request,
+{
+    fn as_ref(&self) -> &R::Payload {
         match &self.0 {
             Inner::Request(req) => req.payload_ref(),
             Inner::Future(_) => already_polled(),

--- a/src/adaptors/cache_me.rs
+++ b/src/adaptors/cache_me.rs
@@ -163,14 +163,27 @@ where
     }
 }
 
-impl<R: Request<Payload = GetMe>> HasPayload for CachedMeRequest<R> {
+impl<R> HasPayload for CachedMeRequest<R>
+where
+    R: Request<Payload = GetMe>,
+{
     type Payload = GetMe;
+}
 
-    fn payload_mut(&mut self) -> &mut Self::Payload {
+impl<R> AsMut<GetMe> for CachedMeRequest<R>
+where
+    R: Request<Payload = GetMe>,
+{
+    fn as_mut(&mut self) -> &mut R::Payload {
         &mut self.1
     }
+}
 
-    fn payload_ref(&self) -> &Self::Payload {
+impl<R> AsRef<GetMe> for CachedMeRequest<R>
+where
+    R: Request<Payload = GetMe>,
+{
+    fn as_ref(&self) -> &R::Payload {
         &self.1
     }
 }

--- a/src/adaptors/throttle.rs
+++ b/src/adaptors/throttle.rs
@@ -517,12 +517,22 @@ pub struct ThrottlingRequest<R: HasPayload>(
 
 impl<R: HasPayload> HasPayload for ThrottlingRequest<R> {
     type Payload = R::Payload;
+}
 
-    fn payload_mut(&mut self) -> &mut Self::Payload {
+impl<R> AsMut<R::Payload> for ThrottlingRequest<R>
+where
+    R: HasPayload,
+{
+    fn as_mut(&mut self) -> &mut R::Payload {
         self.0.payload_mut()
     }
+}
 
-    fn payload_ref(&self) -> &Self::Payload {
+impl<R> AsRef<R::Payload> for ThrottlingRequest<R>
+where
+    R: HasPayload,
+{
+    fn as_ref(&self) -> &R::Payload {
         self.0.payload_ref()
     }
 }

--- a/src/local_macros.rs
+++ b/src/local_macros.rs
@@ -214,6 +214,19 @@ macro_rules! impl_payload {
             }
         }
 
+        impl core::convert::AsRef<Self> for $Method {
+            fn as_ref(&self) -> &Self {
+                self
+            }
+        }
+
+        impl core::convert::AsMut<Self> for $Method {
+            fn as_mut(&mut self) -> &mut Self {
+                self
+            }
+        }
+
+
         impl $crate::requests::Payload for $Method {
             type Output = $Ret;
 

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -16,20 +16,22 @@ use crate::requests::Payload;
 /// [`DerefMut`]: std::ops::DerefMut
 /// [`BorrowMut`]: std::borrow::BorrowMut
 /// [`Payload`]: crate::requests::Payload
-/// [output type]: HasPayload::Payload
-pub trait HasPayload
-// FIXME(waffle):
-//   we wanted to use As{Mut,Ref} here, but they doesn't work
-//   because of https://github.com/rust-lang/rust/issues/77010
+/// [output]: HasPayload::Payload
+pub trait HasPayload:
+    AsRef<<Self as HasPayload>::Payload> + AsMut<<Self as HasPayload>::Payload>
 {
     /// The type of the payload contained.
     type Payload: Payload;
 
     /// Gain mutable access to the underlying payload.
-    fn payload_mut(&mut self) -> &mut Self::Payload;
+    fn payload_mut(&mut self) -> &mut Self::Payload {
+        self.as_mut()
+    }
 
     /// Gain immutable access to the underlying payload.
-    fn payload_ref(&self) -> &Self::Payload;
+    fn payload_ref(&self) -> &Self::Payload {
+        self.as_ref()
+    }
 }
 
 impl<P> HasPayload for P
@@ -37,12 +39,4 @@ where
     P: Payload,
 {
     type Payload = Self;
-
-    fn payload_mut(&mut self) -> &mut Self::Payload {
-        self
-    }
-
-    fn payload_ref(&self) -> &Self::Payload {
-        self
-    }
 }

--- a/src/requests/json.rs
+++ b/src/requests/json.rs
@@ -53,12 +53,16 @@ where
     P: Payload,
 {
     type Payload = P;
+}
 
-    fn payload_mut(&mut self) -> &mut Self::Payload {
+impl<P> AsMut<P> for JsonRequest<P> {
+    fn as_mut(&mut self) -> &mut P {
         &mut self.payload
     }
+}
 
-    fn payload_ref(&self) -> &Self::Payload {
+impl<P> AsRef<P> for JsonRequest<P> {
+    fn as_ref(&self) -> &P {
         &self.payload
     }
 }

--- a/src/requests/multipart.rs
+++ b/src/requests/multipart.rs
@@ -54,12 +54,16 @@ where
     P: Payload,
 {
     type Payload = P;
+}
 
-    fn payload_mut(&mut self) -> &mut Self::Payload {
+impl<P> AsMut<P> for MultipartRequest<P> {
+    fn as_mut(&mut self) -> &mut P {
         &mut self.payload
     }
+}
 
-    fn payload_ref(&self) -> &Self::Payload {
+impl<P> AsRef<P> for MultipartRequest<P> {
+    fn as_ref(&self) -> &P {
         &self.payload
     }
 }

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -6,7 +6,7 @@
 /// Also, this trait provides some additional information needed to send a
 /// request to Telegram.
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
-pub trait Payload {
+pub trait Payload: AsRef<Self> + AsMut<Self> {
     /// The return type of a Telegram method.
     ///
     /// Note: it should not include `Result` wrappers (e.g. it should be simply


### PR DESCRIPTION
This pr resolves `FIXME(waffle)` introduced in #7 (f3e000533575e238e038d25645fb2655d26d7f2d) - compiler bug (https://github.com/rust-lang/rust/issues/77010) was fixed on nightly.

Though note that this currently does not work on stable, nor does it work on beta. We may want to wait until rustc `1.49.0` release (31 December 2020) or at least beta release.