### PR TITLE
Make the trait bounds in Request{,er} stricter

### DIFF
--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -1705,6 +1705,8 @@ impl Bot {
 }
 
 impl Requester for Bot {
+    type Err = crate::errors::RequestError;
+
     type GetMe = JsonRequest<payloads::GetMe>;
 
     fn get_me(&self) -> JsonRequest<payloads::GetMe> {

--- a/src/bot/auto_send.rs
+++ b/src/bot/auto_send.rs
@@ -63,6 +63,8 @@ impl<B> AutoSend<B> {
 }
 
 impl<B: Requester> Requester for AutoSend<B> {
+    type Err = B::Err;
+
     type GetMe = AutoRequest<B::GetMe>;
 
     fn get_me(&self) -> Self::GetMe {

--- a/src/bot/cache_me.rs
+++ b/src/bot/cache_me.rs
@@ -54,7 +54,12 @@ impl<B> CacheMe<B> {
     }
 }
 
-impl<B: Requester> Requester for CacheMe<B> {
+impl<B> Requester for CacheMe<B>
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
     type GetMe = CachedMeRequest<B::GetMe>;
 
     fn get_me(&self) -> Self::GetMe {
@@ -85,7 +90,10 @@ enum Inner<R: Request<Payload = GetMe>> {
     Pending(R, Arc<OnceCell<User>>),
 }
 
-impl<R: Request<Payload = GetMe>> Request for CachedMeRequest<R> {
+impl<R> Request for CachedMeRequest<R>
+where
+    R: Request<Payload = GetMe>,
+{
     type Err = R::Err;
     type Send = Send<R>;
     type SendRef = SendRef<R>;

--- a/src/bot/limits.rs
+++ b/src/bot/limits.rs
@@ -346,7 +346,12 @@ impl<B> Throttle<B> {
     }
 }
 
-impl<B: Requester> Requester for Throttle<B> {
+impl<B: Requester> Requester for Throttle<B>
+where
+    B::SendMessage: Send,
+{
+    type Err = B::Err;
+
     type GetMe = B::GetMe;
 
     fn get_me(&self) -> Self::GetMe {
@@ -412,8 +417,9 @@ impl<R: HasPayload> HasPayload for ThrottlingRequest<R> {
     }
 }
 
-impl<R: Request> Request for ThrottlingRequest<R>
+impl<R> Request for ThrottlingRequest<R>
 where
+    R: Request + Send,
     <R as HasPayload>::Payload: GetChatId,
 {
     type Err = R::Err;
@@ -617,7 +623,7 @@ mod chan_send {
     pub(super) struct ChanSend(#[pin] Inner);
 
     #[cfg(not(feature = "nightly"))]
-    type Inner = Pin<Box<dyn Future<Output = Result<(), SendError<(Id, Sender<Never>)>>>>>;
+    type Inner = Pin<Box<dyn Future<Output = Result<(), SendError<(Id, Sender<Never>)>>> + Send>>;
     #[cfg(feature = "nightly")]
     type Inner = impl Future<Output = Result<(), SendError<(Id, Sender<Never>)>>>;
 

--- a/src/local_macros.rs
+++ b/src/local_macros.rs
@@ -83,7 +83,7 @@ macro_rules! req_future {
 
             #[cfg(not(feature = "nightly"))]
             pub(crate) type $i<$T>
-            $(where $($wh)*)?  = ::core::pin::Pin<Box<dyn ::core::future::Future<Output = $Out>>>;
+            $(where $($wh)*)?  = ::core::pin::Pin<Box<dyn ::core::future::Future<Output = $Out> + ::core::marker::Send + 'static>>;
 
             #[cfg(not(feature = "nightly"))]
             pub(crate) fn def<$T>($( $arg: $ArgTy ),*) -> $i<$T>

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -22,16 +22,16 @@ pub trait Request: HasPayload {
      */
 
     /// Type of error that may happen during sending the request to telegram.
-    type Err: std::error::Error;
+    type Err: std::error::Error + Send;
 
     /// Type of future returned by [`send`](Request::send) method.
-    type Send: Future<Output = Result<Output<Self>, Self::Err>>;
+    type Send: Future<Output = Result<Output<Self>, Self::Err>> + Send;
 
     /// Type of future returned by [`send_ref`](Request::send_ref) method.
     ///
     /// NOTE: it intentionally forbids borrowing from self
     // though anyway we couldn't allow borrowing without GATs :sob:
-    type SendRef: Future<Output = Result<Output<Self>, Self::Err>>;
+    type SendRef: Future<Output = Result<Output<Self>, Self::Err>> + Send;
 
     /// Send the request.
     ///

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -10,12 +10,14 @@ use crate::{
 /// _This trait is included in the crate's [`prelude`](crate::prelude)_.
 #[cfg_attr(all(docsrs, feature = "nightly"), doc(spotlight))]
 pub trait Requester {
-    type GetMe: Request<Payload = GetMe>;
+    type Err: std::error::Error + Send;
+
+    type GetMe: Request<Payload = GetMe, Err = Self::Err>;
 
     /// For telegram documentation of the method see [`GetMe`].
     fn get_me(&self) -> Self::GetMe;
 
-    type SendMessage: Request<Payload = SendMessage>;
+    type SendMessage: Request<Payload = SendMessage, Err = Self::Err>;
 
     /// For telegram documentation of the method see [`SendMessage`].
     fn send_message<C, T>(&self, chat_id: C, text: T) -> Self::SendMessage


### PR DESCRIPTION
- Add `Err` associated type to `Requester`, containing all requests to have the same `Err`.
- Add `core::marker::Send` bound for `Request::{Err,Send,SendRef}` associated types.

Pros: easier to write user code, cons: harder to write teloxide itself.