### PR TITLE
Rename `StickerType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename `StickerType` => `InputSticker`, `{CreateNewStickerSet,AddStickerToSet}::sticker_type}` => `sticker` ([#23][pr23])
+- Use `_: IntoIterator<Item = T>` bound instead of `_: Into<Vec<T>>` in telegram methods which accept collections ([#21][pr21])
+- Make `MessageDice::dice` pub ([#20][pr20])
 - Merge `ApiErrorKind` and `KnownApiErrorKind` into `ApiError` ([#13][pr13])
 - Refactor ChatMember ([#9][pr9])
   - Replace a bunch of `Option<_>` fields with `ChatMemberKind`
@@ -55,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [pr9]: https://github.com/teloxide/teloxide-core/pull/9
 [pr13]: https://github.com/teloxide/teloxide-core/pull/13
+[pr20]: https://github.com/teloxide/teloxide-core/pull/20
+[pr21]: https://github.com/teloxide/teloxide-core/pull/21
+[pr23]: https://github.com/teloxide/teloxide-core/pull/23
 
 ### Removed
 

--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     types::{
         BotCommand, ChatId, ChatPermissions, InlineQueryResult, InputFile, InputMedia,
-        LabeledPrice, ParseMode, InputSticker, TargetMessage,
+        InputSticker, LabeledPrice, ParseMode, TargetMessage,
     },
     Bot,
 };

--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     types::{
         BotCommand, ChatId, ChatPermissions, InlineQueryResult, InputFile, InputMedia,
-        LabeledPrice, ParseMode, StickerType, TargetMessage,
+        LabeledPrice, ParseMode, InputSticker, TargetMessage,
     },
     Bot,
 };
@@ -1366,7 +1366,7 @@ impl Bot {
         user_id: i32,
         name: N,
         title: T,
-        sticker_type: StickerType,
+        sticker_type: InputSticker,
         emojis: E,
     ) -> CreateNewStickerSet
     where
@@ -1389,7 +1389,7 @@ impl Bot {
         &self,
         user_id: i32,
         name: N,
-        sticker_type: StickerType,
+        sticker_type: InputSticker,
         emojis: E,
     ) -> AddStickerToSet
     where

--- a/src/requests/all/add_sticker_to_set.rs
+++ b/src/requests/all/add_sticker_to_set.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use crate::{
     requests::{RequestOld, ResponseResult},
-    types::StickerType,
+    types::InputSticker,
 };
 
 /// Use this method to add a new sticker to a set created by the bot.
@@ -22,7 +22,7 @@ pub struct AddStickerToSet {
     pub user_id: i32,
     pub name: String,
     #[serde(flatten)]
-    pub sticker_type: StickerType,
+    pub sticker_type: InputSticker,
     pub emojis: String,
     pub mask_position: Option<MaskPosition>,
 }
@@ -41,7 +41,7 @@ impl AddStickerToSet {
         bot: Bot,
         user_id: i32,
         name: N,
-        sticker_type: StickerType,
+        sticker_type: InputSticker,
         emojis: E,
     ) -> Self
     where
@@ -73,7 +73,7 @@ impl AddStickerToSet {
         self
     }
 
-    pub fn sticker_type(mut self, val: StickerType) -> Self {
+    pub fn sticker_type(mut self, val: InputSticker) -> Self {
         self.sticker_type = val;
         self
     }

--- a/src/requests/all/create_new_sticker_set.rs
+++ b/src/requests/all/create_new_sticker_set.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::{
     net,
     requests::{RequestOld, ResponseResult},
-    types::{MaskPosition, StickerType, True},
+    types::{MaskPosition, InputSticker, True},
     Bot,
 };
 
@@ -20,7 +20,7 @@ pub struct CreateNewStickerSet {
     pub name: String,
     pub title: String,
     #[serde(flatten)]
-    pub sticker_type: StickerType,
+    pub sticker: InputSticker,
     pub emojis: String,
     pub contains_masks: Option<bool>,
     pub mask_position: Option<MaskPosition>,
@@ -42,7 +42,7 @@ impl CreateNewStickerSet {
         user_id: i32,
         name: N,
         title: T,
-        sticker_type: StickerType,
+        sticker_type: InputSticker,
         emojis: E,
     ) -> Self
     where
@@ -55,7 +55,7 @@ impl CreateNewStickerSet {
             user_id,
             name: name.into(),
             title: title.into(),
-            sticker_type,
+            sticker: sticker_type,
             emojis: emojis.into(),
             contains_masks: None,
             mask_position: None,
@@ -91,8 +91,8 @@ impl CreateNewStickerSet {
         self
     }
 
-    pub fn sticker_type(mut self, val: StickerType) -> Self {
-        self.sticker_type = val;
+    pub fn sticker_type(mut self, val: InputSticker) -> Self {
+        self.sticker = val;
         self
     }
 

--- a/src/requests/all/create_new_sticker_set.rs
+++ b/src/requests/all/create_new_sticker_set.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::{
     net,
     requests::{RequestOld, ResponseResult},
-    types::{MaskPosition, InputSticker, True},
+    types::{InputSticker, MaskPosition, True},
     Bot,
 };
 

--- a/src/types/sticker_type.rs
+++ b/src/types/sticker_type.rs
@@ -31,18 +31,18 @@ pub enum InputSticker {
 impl InputSticker {
     /// Create png-`InputSticker`.
     ///
-    /// See [`StickerType::Png`] for more
+    /// See [`InputSticker::Png`] for more
     ///
-    /// [`StickerType::Png`]: crate::types::StickerType::Png
+    /// [`InputSticker::Png`]: crate::types::InputSticker::Png
     pub fn png(png_sticker: InputFile) -> Self {
         Self::Png { png_sticker }
     }
 
     /// Create tgs-`InputSticker`.
     ///
-    /// See [`StickerType::Tgs`] for more
+    /// See [`InputSticker::Tgs`] for more
     ///
-    /// [`StickerType::Tgs`]: crate::types::StickerType::Tgs
+    /// [`InputSticker::Tgs`]: crate::types::InputSticker::Tgs
     pub fn tgs(tgs_sticker: InputFile) -> Self {
         Self::Tgs { tgs_sticker }
     }

--- a/src/types/sticker_type.rs
+++ b/src/types/sticker_type.rs
@@ -2,9 +2,10 @@ use serde::Serialize;
 
 use crate::types::InputFile;
 
+/// Sticker file that may be uploaded to telegram.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum StickerType {
+pub enum InputSticker {
     /// PNG image with the sticker, must be up to 512 kilobytes in size,
     /// dimensions must not exceed 512px, and either width or height must be
     /// exactly 512px.
@@ -27,8 +28,8 @@ pub enum StickerType {
     Tgs { tgs_sticker: InputFile },
 }
 
-impl StickerType {
-    /// Create png-`StickerType`.
+impl InputSticker {
+    /// Create png-`InputSticker`.
     ///
     /// See [`StickerType::Png`] for more
     ///
@@ -37,7 +38,7 @@ impl StickerType {
         Self::Png { png_sticker }
     }
 
-    /// Create tgs-`StickerType`.
+    /// Create tgs-`InputSticker`.
     ///
     /// See [`StickerType::Tgs`] for more
     ///


### PR DESCRIPTION
- Rename `StickerType` => `InputSticker`
- Rename `{CreateNewStickerSet,AddStickerToSet}::sticker_type}` => `sticker`

This just makes more sense.