### PR TITLE
Support rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ vecrem = { git = "https://github.com/WaffleLapkin/vecrem", rev = "6b9b6f42342df8
 [features]
 default = []
 
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 
 # Features which require nightly compiler.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ never = "0.1.0"
 vecrem = { git = "https://github.com/WaffleLapkin/vecrem", rev = "6b9b6f42342df8b75548c6ed387072ff235429b1" }
 
 [features]
-default = []
+default = ["native-tls"]
 
 rustls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ vecrem = { git = "https://github.com/WaffleLapkin/vecrem", rev = "6b9b6f42342df8
 [features]
 default = []
 
+rustls = ["reqwest/rustls"]
+native-tls = ["reqwest/native-tls"]
+
 # Features which require nightly compiler.
 #
 # Currently the only used compiler feature is feature(type_alias_impl_trait)


### PR DESCRIPTION
This was teloxide-based applications can be easily compiled for musl
targets.