### PR TITLE
Add internal ability to change API url

### DIFF
--- a/src/bot/api_url.rs
+++ b/src/bot/api_url.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone)]
 pub(crate) enum ApiUrl {
     Default,
+    // FIXME: remove #[allow] when we use this variant
     #[allow(dead_code)]
     Custom(reqwest::Url),
 }

--- a/src/bot/api_url.rs
+++ b/src/bot/api_url.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Clone)]
+pub(crate) enum ApiUrl {
+    Default,
+    #[allow(dead_code)]
+    Custom(reqwest::Url),
+}
+
+impl ApiUrl {
+    pub(crate) fn get(&self) -> reqwest::Url {
+        match self {
+            // FIXME(waffle): parse once
+            ApiUrl::Default => reqwest::Url::parse(crate::net::TELEGRAM_API_URL)
+                .expect("failed to parse default url"),
+            ApiUrl::Custom(url) => url.clone(),
+        }
+    }
+}

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -3,8 +3,6 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::errors::DownloadError;
 
-use super::TELEGRAM_API_URL;
-
 pub async fn download_file<D>(
     client: &Client,
     token: &str,
@@ -15,7 +13,11 @@ where
     D: AsyncWrite + Unpin,
 {
     let mut res = client
-        .get(&super::file_url(TELEGRAM_API_URL, token, path))
+        .get(crate::net::file_url(
+            reqwest::Url::parse(crate::net::TELEGRAM_API_URL).expect("failed to parse default url"),
+            token,
+            path,
+        ))
         .send()
         .await?
         .error_for_status()?;
@@ -33,7 +35,11 @@ pub async fn download_file_stream(
     path: &str,
 ) -> Result<impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>, reqwest::Error> {
     let res = client
-        .get(&super::file_url(TELEGRAM_API_URL, token, path))
+        .get(crate::net::file_url(
+            reqwest::Url::parse(crate::net::TELEGRAM_API_URL).expect("failed to parse default url"),
+            token,
+            path,
+        ))
         .send()
         .await?
         .error_for_status()?;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,36 +8,38 @@ mod download;
 mod request;
 mod telegram_response;
 
-const TELEGRAM_API_URL: &str = "https://api.telegram.org";
+pub(crate) const TELEGRAM_API_URL: &str = "https://api.telegram.org";
 
 /// Creates URL for making HTTPS requests. See the [Telegram documentation].
 ///
 /// [Telegram documentation]: https://core.telegram.org/bots/api#making-requests
-fn method_url(base: &str, token: &str, method_name: &str) -> String {
-    format!("{url}/bot{token}/{method}", url = base, token = token, method = method_name)
+fn method_url(base: reqwest::Url, token: &str, method_name: &str) -> reqwest::Url {
+    base.join(&format!("/bot{token}/{method}", token = token, method = method_name))
+        .expect("failed to format url")
 }
 
 /// Creates URL for downloading a file. See the [Telegram documentation].
 ///
 /// [Telegram documentation]: https://core.telegram.org/bots/api#file
-fn file_url(base: &str, token: &str, file_path: &str) -> String {
-    format!("{url}/file/bot{token}/{file}", url = base, token = token, file = file_path,)
+fn file_url(base: reqwest::Url, token: &str, file_path: &str) -> reqwest::Url {
+    base.join(&format!("file/bot{token}/{file}", token = token, file = file_path))
+        .expect("failed to format url")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::net::*;
 
     #[test]
     fn method_url_test() {
         let url = method_url(
-            TELEGRAM_API_URL,
+            reqwest::Url::parse(TELEGRAM_API_URL).unwrap(),
             "535362388:AAF7-g0gYncWnm5IyfZlpPRqRRv6kNAGlao",
             "methodName",
         );
 
         assert_eq!(
-            url,
+            url.as_str(),
             "https://api.telegram.org/bot535362388:AAF7-g0gYncWnm5IyfZlpPRqRRv6kNAGlao/methodName"
         );
     }
@@ -45,13 +47,13 @@ mod tests {
     #[test]
     fn file_url_test() {
         let url = file_url(
-            TELEGRAM_API_URL,
+            reqwest::Url::parse(TELEGRAM_API_URL).unwrap(),
             "535362388:AAF7-g0gYncWnm5IyfZlpPRqRRv6kNAGlao",
             "AgADAgADyqoxG2g8aEsu_KjjVsGF4-zetw8ABAEAAwIAA20AA_8QAwABFgQ",
         );
 
         assert_eq!(
-            url,
+            url.as_str(),
             "https://api.telegram.org/file/bot535362388:AAF7-g0gYncWnm5IyfZlpPRqRRv6kNAGlao/AgADAgADyqoxG2g8aEsu_KjjVsGF4-zetw8ABAEAAwIAA20AA_8QAwABFgQ"
         );
     }

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -72,6 +72,7 @@ where
 pub async fn request_multipart2<T>(
     client: &Client,
     token: &str,
+    api_url: Option<&str>,
     method_name: &str,
     params: reqwest::multipart::Form,
 ) -> ResponseResult<T>
@@ -79,7 +80,7 @@ where
     T: DeserializeOwned,
 {
     let response = client
-        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .post(&super::method_url(api_url.unwrap_or(TELEGRAM_API_URL), token, method_name))
         .multipart(params)
         .send()
         .await
@@ -91,6 +92,7 @@ where
 pub async fn request_json2<T>(
     client: &Client,
     token: &str,
+    api_url: Option<&str>,
     method_name: &str,
     params: Vec<u8>,
 ) -> ResponseResult<T>
@@ -98,7 +100,7 @@ where
     T: DeserializeOwned,
 {
     let response = client
-        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .post(&super::method_url(api_url.unwrap_or(TELEGRAM_API_URL), token, method_name))
         .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
         .body(params)
         .send()

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -35,7 +35,11 @@ where
     };
 
     let response = client
-        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .post(crate::net::method_url(
+            reqwest::Url::parse(TELEGRAM_API_URL).expect("failed to parse default url"),
+            token,
+            method_name,
+        ))
         .multipart(form)
         .send()
         .await
@@ -55,7 +59,11 @@ where
     R: DeserializeOwned,
 {
     let response = client
-        .post(&super::method_url(TELEGRAM_API_URL, token, method_name))
+        .post(crate::net::method_url(
+            reqwest::Url::parse(TELEGRAM_API_URL).expect("failed to parse default url"),
+            token,
+            method_name,
+        ))
         .json(params)
         .send()
         .await
@@ -72,7 +80,7 @@ where
 pub async fn request_multipart2<T>(
     client: &Client,
     token: &str,
-    api_url: Option<&str>,
+    api_url: reqwest::Url,
     method_name: &str,
     params: reqwest::multipart::Form,
 ) -> ResponseResult<T>
@@ -80,7 +88,7 @@ where
     T: DeserializeOwned,
 {
     let response = client
-        .post(&super::method_url(api_url.unwrap_or(TELEGRAM_API_URL), token, method_name))
+        .post(crate::net::method_url(api_url, token, method_name))
         .multipart(params)
         .send()
         .await
@@ -92,7 +100,7 @@ where
 pub async fn request_json2<T>(
     client: &Client,
     token: &str,
-    api_url: Option<&str>,
+    api_url: reqwest::Url,
     method_name: &str,
     params: Vec<u8>,
 ) -> ResponseResult<T>
@@ -100,7 +108,7 @@ where
     T: DeserializeOwned,
 {
     let response = client
-        .post(&super::method_url(api_url.unwrap_or(TELEGRAM_API_URL), token, method_name))
+        .post(crate::net::method_url(api_url, token, method_name))
         .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
         .body(params)
         .send()


### PR DESCRIPTION
Recently, telegram has published [Telegram Bot API Server] - HTTP API <->
MTPROTO proxy which is used internally by telegram. Now it's possible to run
the server locally.

However currently it's not possible to use teloxide with such local server,
because API url is hardcoded into teloxide.

This commit makes _internall_ changes to allow setting the API url. It doesn't
yet allow to set the url from user code (i.e.: no changes in public API), in my
opinion such additions are blocked on some bot refactorings.

`Bot::api_url` is made `Option<Arc<str>>` to minimize costs in case of 'default
url' (probably the most common case).

Progress of this issue is tracked in https://github.com/teloxide/teloxide/issues/317

[Telegram Bot API Server]: https://github.com/tdlib/telegram-bot-api
