### PR TITLE
Add forward-to-deref Requester impls

### DIFF
--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -715,3 +715,88 @@ pub trait Requester {
     where
         T: Into<TargetMessage>;
 }
+
+macro_rules! fty {
+    ($T:ident) => {
+        B::$T
+    };
+}
+
+macro_rules! fwd_deref {
+    ($m:ident $this:ident ($($arg:ident : $T:ty),*)) => {
+        core::ops::Deref::deref($this).$m($($arg),*)
+    };
+}
+
+macro_rules! forward_all {
+    () => {
+        requester_forward! {
+            get_me, get_updates, set_webhook, delete_webhook, get_webhook_info,
+            forward_message, send_message, send_photo, send_audio, send_document, send_video,
+            send_animation, send_voice, send_video_note, send_media_group, send_location,
+            edit_message_live_location, edit_message_live_location_inline,
+            stop_message_live_location, stop_message_live_location_inline, send_venue,
+            send_contact, send_poll, send_dice, send_chat_action, get_user_profile_photos,
+            get_file, kick_chat_member, unban_chat_member, restrict_chat_member,
+            promote_chat_member, set_chat_administrator_custom_title, set_chat_permissions,
+            export_chat_invite_link, set_chat_photo, delete_chat_photo, set_chat_title,
+            set_chat_description, pin_chat_message, unpin_chat_message, leave_chat,
+            get_chat, get_chat_administrators, get_chat_members_count,get_chat_member,
+            set_chat_sticker_set, delete_chat_sticker_set, answer_callback_query,
+            set_my_commands, get_my_commands, answer_inline_query, edit_message_text,
+            edit_message_text_inline, edit_message_caption, edit_message_caption_inline,
+            edit_message_media, edit_message_media_inline, edit_message_reply_markup,
+            edit_message_reply_markup_inline, stop_poll, delete_message, send_sticker,
+            get_sticker_set, upload_sticker_file, create_new_sticker_set,
+            add_sticker_to_set, set_sticker_position_in_set, delete_sticker_from_set,
+            set_sticker_set_thumb, send_invoice, answer_shipping_query,
+            answer_pre_checkout_query, set_passport_data_errors, send_game,
+            set_game_score, set_game_score_inline, get_game_high_scores => fwd_deref, fty
+        }
+    };
+}
+
+impl<B> Requester for &B
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
+    forward_all! {}
+}
+
+impl<B> Requester for &mut B
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
+    forward_all! {}
+}
+
+impl<B> Requester for Box<B>
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
+    forward_all! {}
+}
+
+impl<B> Requester for std::sync::Arc<B>
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
+    forward_all! {}
+}
+
+impl<B> Requester for std::rc::Rc<B>
+where
+    B: Requester,
+{
+    type Err = B::Err;
+
+    forward_all! {}
+}


### PR DESCRIPTION
This PR adds
```rust
impl<B: Requester> Requester for D<B> { ... }
```
where `D<_>` is `&_`, `&mut _`, `Box<_>`, `Arc<_>` and `Rc<_>`.
