### PR TITLE
feat: Add a way to override default telegram api server

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TELEGRAM_API_URL={}",
+        option_env!("TELEGRAM_API_URL").unwrap_or("https://api.telegram.org")
+    );
+}

--- a/src/net.rs
+++ b/src/net.rs
@@ -12,7 +12,7 @@ mod request;
 mod telegram_response;
 
 /// The default Telegram API URL.
-pub const TELEGRAM_API_URL: &str = "https://api.telegram.org";
+pub const TELEGRAM_API_URL: &str = env!("TELEGRAM_API_URL");
 
 /// Constructs a network client from the `TELOXIDE_PROXY` environmental
 /// variable.


### PR DESCRIPTION
* See: https://core.telegram.org/bots/api#using-a-local-bot-api-server