### PR TITLE
(For instant release) Fix typo: `ReplyMarkup::{keyboad => keyboard}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typo: `ReplyMarkup::{keyboad => keyboard}` ([#69][pr69])
   - Note: method with the old name was deprecated and hidden from docs
 
+[pr69]: https://github.com/teloxide/teloxide-core/pull/69
+
 ## [0.2.1] - 2020-03-19
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.2.2] - 2020-03-22
+
+### Fixed
+
+- Typo: `ReplyMarkup::{keyboad => keyboard}` ([#69][pr69])
+  - Note: method with the old name was deprecated and hidden from docs
+
 ## [0.2.1] - 2020-03-19
 
 ### Fixed 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = [
     "Temirkhan Myrzamadi <hirrolot@gmail.com>",

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Commonly used items.
 
+#[doc(no_inline)]
 pub use crate::{
     payloads::setters::*,
     requests::{Request, Requester, RequesterExt},

--- a/src/types/reply_markup.rs
+++ b/src/types/reply_markup.rs
@@ -36,7 +36,7 @@ impl ReplyMarkup {
     /// `ReplyMarkup::Keyboard(KeyboardMarkup::new(_))`.
     ///
     /// [`Keyboard`]: ReplyMarkup::Keyboard
-    pub fn keyboad<K>(keyboard: K) -> Self
+    pub fn keyboard<K>(keyboard: K) -> Self
     where
         K: IntoIterator,
         K::Item: IntoIterator<Item = KeyboardButton>,
@@ -61,6 +61,17 @@ impl ReplyMarkup {
     /// [`ForceReply`]: ReplyMarkup::KeyboardRemove
     pub fn force_reply() -> Self {
         Self::ForceReply(ForceReply::new())
+    }
+
+    // FIXME(waffle): remove this method in the next minor version bump (0.3.0)
+    #[doc(hidden)]
+    #[deprecated = "This method has a typo in name. Use `ReplyMarkup::keyboard` instead."]
+    pub fn keyboad<K>(keyboard: K) -> Self
+    where
+        K: IntoIterator,
+        K::Item: IntoIterator<Item = KeyboardButton>,
+    {
+        Self::Keyboard(KeyboardMarkup::new(keyboard))
     }
 }
 


### PR DESCRIPTION
- doc(no_inline) prelude reexports
- Fix typo: `ReplyMarkup::{keyboad => keyboard}`
- Bump version (0.2.1 => 0.2.2)
