### PR TITLE
fix reqwest dependency features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- `reqwest` dependency bringing `native-tls` in even when `rustls` was selected ([#71][pr71])
+
+[pr71]: https://github.com/teloxide/teloxide-core/pull/71
+
 ## [0.2.2] - 2020-03-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1.2.0", features = ["fs"] }
 tokio-util = "0.6.0"
 pin-project = "1.0.3"
 bytes = "1.0.0"
-reqwest = { version = "0.11.0", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.11.0", features = ["json", "stream", "multipart"], default-features = false }
 log = "0.4"
 
 serde = { version = "1.0.114", features = ["derive"] }


### PR DESCRIPTION
The reqwest dependency brings the `native-tls` in as part of its default features, even if the `rustls` feature is specified. Adding `default-features = false` fixes the problem.
