### PR TITLE
Fix return types of methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Output types of `LeaveChat` `PinChatMessage`, `SetChatDescription`, `SetChatPhoto` `SetChatTitle`, `UnpinAllChatMessages` and `UnpinChatMessage`: `String` => `True` ([#79][pr79])
 - `SendChatAction` output type `Message` => `True` ([#75][pr75])
 - `GetChatAdministrators` output type `ChatMember` => `Vec<ChatMember>` ([#73][pr73])
 - `reqwest` dependency bringing `native-tls` in even when `rustls` was selected ([#71][pr71])
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [pr71]: https://github.com/teloxide/teloxide-core/pull/71
 [pr73]: https://github.com/teloxide/teloxide-core/pull/73
 [pr75]: https://github.com/teloxide/teloxide-core/pull/75
+[pr79]: https://github.com/teloxide/teloxide-core/pull/79
 
 ## [0.2.2] - 2020-03-22
 

--- a/src/payloads/leave_chat.rs
+++ b/src/payloads/leave_chat.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method for your bot to leave a group, supergroup or channel. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub LeaveChat (LeaveChatSetters) => String {
+    pub LeaveChat (LeaveChatSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/pin_chat_message.rs
+++ b/src/payloads/pin_chat_message.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method to pin a message in a group, a supergroup, or a channel. The bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in the supergroup or 'can_edit_messages' admin right in the channel. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub PinChatMessage (PinChatMessageSetters) => String {
+    pub PinChatMessage (PinChatMessageSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/set_chat_description.rs
+++ b/src/payloads/set_chat_description.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method to change the description of a group, a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub SetChatDescription (SetChatDescriptionSetters) => String {
+    pub SetChatDescription (SetChatDescriptionSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/set_chat_photo.rs
+++ b/src/payloads/set_chat_photo.rs
@@ -8,13 +8,13 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::{ChatId, InputFile};
+use crate::types::{ChatId, InputFile, True};
 
 impl_payload! {
     @[multipart]
     /// Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub SetChatPhoto (SetChatPhotoSetters) => String {
+    pub SetChatPhoto (SetChatPhotoSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/set_chat_title.rs
+++ b/src/payloads/set_chat_title.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub SetChatTitle (SetChatTitleSetters) => String {
+    pub SetChatTitle (SetChatTitleSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/unpin_all_chat_messages.rs
+++ b/src/payloads/unpin_all_chat_messages.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method to clear the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub UnpinAllChatMessages (UnpinAllChatMessagesSetters) => String {
+    pub UnpinAllChatMessages (UnpinAllChatMessagesSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],

--- a/src/payloads/unpin_chat_message.rs
+++ b/src/payloads/unpin_chat_message.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::ChatId;
+use crate::types::{ChatId, True};
 
 impl_payload! {
     /// Use this method to remove a message from the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub UnpinChatMessage (UnpinChatMessageSetters) => String {
+    pub UnpinChatMessage (UnpinChatMessageSetters) => True {
         required {
             /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
             pub chat_id: ChatId [into],


### PR DESCRIPTION
Fix return types of `LeaveChat`, `PinChatMessage`, `SetChatDescription`, `SetChatPhoto`, `SetChatTitle`, `UnpinAllChatMessages` and `UnpinChatMessage`: `String` => `True`.

Thanks, @Aloxaf for finding & fixing typos in the schema.