### PR TITLE
Add `net::default_reqwest_settings` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Getters for fields nested in `Chat` ([#80][pr80]) 
 - API errors: `ApiError::NotEnoughRightsToManagePins`, `ApiError::BotKickedFromSupergroup` ([#84][pr84])
 - Telegram bot API 5.2 support ([#86][pr86])
+- `net::default_reqwest_settings` function ([#90][pr90])
 
 [pr75]: https://github.com/teloxide/teloxide-core/pull/75
 [pr80]: https://github.com/teloxide/teloxide-core/pull/80
 [pr84]: https://github.com/teloxide/teloxide-core/pull/84
 [pr86]: https://github.com/teloxide/teloxide-core/pull/86
+[pr90]: https://github.com/teloxide/teloxide-core/pull/90
 
 ### Changed
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -51,19 +51,21 @@ pub fn client_from_env() -> reqwest::Client {
 
 /// Returns a reqwest client builder with default settings.
 ///
-/// Client built from default settings is supposed to work in long time
+/// Client built from default settings is supposed to work over long time
 /// durations, see the [issue 223].
 ///
-/// Current setting are:
-/// - `connection/keep-alive` default header
-/// - connection timeout of 5 seconds
-/// - timeout of 17 seconds
-/// - tcp_nodelay is on
+/// The current settings are:
+///  - The `connection/keep-alive` default header.
+///  - A connection timeout of 5 seconds.
+///  - A timeout of 17 seconds.
+///  - `tcp_nodelay` is on.
 ///
-/// Notes:
-/// 1. the settings may change in the future
-/// 2. if you are using polling mechanizm to get updates, the timeout configured
-///    in the client should be bigger than polling timeout
+/// ## Notes
+/// 1. The settings may change in the future.
+/// 2. If you are using the polling mechanism to get updates, the timeout
+///    configured in the client should be bigger than the polling timeout.
+/// 3. If you alter the current settings listed above, your bot will not be
+///    guaranteed to work over long time durations.
 ///
 /// [issue 223]: https://github.com/teloxide/teloxide/issues/223
 pub fn default_reqwest_settings() -> reqwest::ClientBuilder {

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,5 +1,7 @@
 //! Network-specific API.
 
+use std::time::Duration;
+
 pub use self::download::{download_file, download_file_stream, Download};
 
 pub(crate) use self::{
@@ -33,17 +35,51 @@ pub const TELEGRAM_API_URL: &str = "https://api.telegram.org";
 ///
 /// If `TELOXIDE_PROXY` exists, but isn't correct url.
 pub fn client_from_env() -> reqwest::Client {
-    use crate::bot::{sound_bot, TELOXIDE_PROXY};
     use reqwest::Proxy;
 
-    let builder = sound_bot();
+    const TELOXIDE_PROXY: &str = "TELOXIDE_PROXY";
+
+    let builder = default_reqwest_settings();
 
     match std::env::var(TELOXIDE_PROXY).ok() {
-        Some(proxy) => builder.proxy(Proxy::all(&proxy).expect("creating reqwest::Proxy")),
+        Some(proxy) => builder.proxy(Proxy::all(&proxy).expect("reqwest::Proxy creation failed")),
         None => builder,
     }
     .build()
     .expect("creating reqwest::Client")
+}
+
+/// Returns a reqwest client builder with default settings.
+///
+/// Client built from default settings is supposed to work in long time
+/// durations, see the [issue 223].
+///
+/// Current setting are:
+/// - `connection/keep-alive` default header
+/// - connection timeout of 5 seconds
+/// - timeout of 17 seconds
+/// - tcp_nodelay is on
+///
+/// Notes:
+/// 1. the settings may change in the future
+/// 2. if you are using polling mechanizm to get updates, the timeout configured
+///    in the client should be bigger than polling timeout
+///
+/// [issue 223]: https://github.com/teloxide/teloxide/issues/223
+pub fn default_reqwest_settings() -> reqwest::ClientBuilder {
+    use reqwest::header::{HeaderMap, CONNECTION};
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CONNECTION, "keep-alive".parse().unwrap());
+
+    let connect_timeout = Duration::from_secs(5);
+    let timeout = connect_timeout + Duration::from_secs(12);
+
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(timeout)
+        .tcp_nodelay(true)
+        .default_headers(headers)
 }
 
 /// Creates URL for making HTTPS requests. See the [Telegram documentation].


### PR DESCRIPTION
This function can help when users want to set up their own client setting for
one reason or another, since settings set by the function, are required for
stable work.

This function was previously private and named `sound_bot`. The old name was
confusing since safety and soundness are used in the Rust context almost
entirely for `unsafe` code, UB & co. So I've changed the name to a more
descriptive one.
