### PR TITLE
Resolve FIXME in `HasPayload`: we've decided to not add `As{Mut,Ref}` bounds

### DIFF
--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -17,11 +17,7 @@ use crate::requests::Payload;
 /// [`BorrowMut`]: std::borrow::BorrowMut
 /// [`Payload`]: crate::requests::Payload
 /// [output type]: HasPayload::Payload
-pub trait HasPayload
-// FIXME(waffle):
-//   we wanted to use As{Mut,Ref} here, but they doesn't work
-//   because of https://github.com/rust-lang/rust/issues/77010
-{
+pub trait HasPayload {
     /// The type of the payload contained.
     type Payload: Payload;
 

--- a/src/types/audio.rs
+++ b/src/types/audio.rs
@@ -80,7 +80,7 @@ mod tests {
             }),
             file_name: None,
         };
-        let actual = serde_json::from_str::<Audio>(&json).unwrap();
+        let actual = serde_json::from_str::<Audio>(json).unwrap();
         assert_eq!(actual, expected)
     }
 }

--- a/src/types/chat_member.rs
+++ b/src/types/chat_member.rs
@@ -625,7 +625,7 @@ mod tests {
                 can_promote_members: true,
             }),
         };
-        let actual = serde_json::from_str::<ChatMember>(&json).unwrap();
+        let actual = serde_json::from_str::<ChatMember>(json).unwrap();
         assert_eq!(actual, expected)
     }
 }

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -66,7 +66,7 @@ mod tests {
             username: Some("Username".to_string()),
             language_code: Some(String::from("ru")),
         };
-        let actual = serde_json::from_str::<User>(&json).unwrap();
+        let actual = serde_json::from_str::<User>(json).unwrap();
         assert_eq!(actual, expected)
     }
 }


### PR DESCRIPTION
See https://github.com/teloxide/teloxide-core/pull/11