### PR TITLE
telegram_response: fix issue `retry_after` and `migrate_to_chat_id` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- telegram_response: fix issue `retry_after` and `migrate_to_chat_id` handling ([#94][pr94])
 - Type of `PublicChatSupergroup::slow_mode_delay` field: `Option<i32>`=> `Option<u32>` ([#80][pr80]) 
 - Add missing `Chat::message_auto_delete_time` field ([#80][pr80]) 
 - Output types of `LeaveChat` `PinChatMessage`, `SetChatDescription`, `SetChatPhoto` `SetChatTitle`, `UnpinAllChatMessages` and `UnpinChatMessage`: `String` => `True` ([#79][pr79])
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [pr73]: https://github.com/teloxide/teloxide-core/pull/73
 [pr75]: https://github.com/teloxide/teloxide-core/pull/75
 [pr79]: https://github.com/teloxide/teloxide-core/pull/79
+[pr94]: https://github.com/teloxide/teloxide-core/pull/94
 
 ## [0.2.2] - 2020-03-22
 

--- a/src/net/telegram_response.rs
+++ b/src/net/telegram_response.rs
@@ -25,6 +25,7 @@ pub(crate) enum TelegramResponse<R> {
         #[serde(rename = "description")]
         error: ApiError,
         error_code: u16,
+        #[serde(rename = "parameters")]
         response_parameters: Option<ResponseParameters>,
     },
 }


### PR DESCRIPTION
According to https://core.telegram.org/bots/api#making-requests, now the error struct is contained in the `parameters` field.

In this Pull Request,  the field is renamed to adapt to this change.