### PR TITLE
Fix rt-tys of `{get,set}_my_commands` methods

### DIFF
--- a/src/payloads/get_my_commands.rs
+++ b/src/payloads/get_my_commands.rs
@@ -8,12 +8,14 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
+use crate::types::BotCommand;
+
 impl_payload! {
     /// Use this method to get the current list of the bot's commands. Requires no parameters. Returns Array of [`BotCommand`] on success.
     ///
     /// [`BotCommand`]: crate::types::BotCommand
     #[derive(Debug, PartialEq, Eq, Hash, Default, Clone, Serialize)]
-    pub GetMyCommands (GetMyCommandsSetters) => u32 {
+    pub GetMyCommands (GetMyCommandsSetters) => Vec<BotCommand> {
 
     }
 }

--- a/src/payloads/set_my_commands.rs
+++ b/src/payloads/set_my_commands.rs
@@ -8,12 +8,12 @@
 // [`schema`]: https://github.com/WaffleLapkin/tg-methods-schema
 use serde::Serialize;
 
-use crate::types::BotCommand;
+use crate::types::{BotCommand, True};
 
 impl_payload! {
     /// Use this method to change the list of the bot's commands. Returns _True_ on success.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize)]
-    pub SetMyCommands (SetMyCommandsSetters) => u32 {
+    pub SetMyCommands (SetMyCommandsSetters) => True {
         required {
             /// A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
             pub commands: Vec<BotCommand> [collect],


### PR DESCRIPTION
Fix return types of `get_my_commands` (`u32` => `True`) and `set_my commands` (`u32` => `Vec<BotCommand>`).

Fixes https://github.com/teloxide/teloxide/issues/402

See also: https://github.com/WaffleLapkin/tg-methods-schema/pull/38