### PR TITLE
0.3.1 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Changed
+## 0.3.1 - 2021-07-07
 
 - Minor documentation tweaks ([#102][pr102])
 - Remove `Self: 'static` buound on `RequesterExt::throttle` ([#102][pr102])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor documentation tweaks ([#102][pr102])
+- Remove `Self: 'static` buound on `RequesterExt::throttle` ([#102][pr102])
 
 [pr102]: https://github.com/teloxide/teloxide-core/pull/102
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- Minor documentation tweaks ([#102][pr102])
+
+[pr102]: https://github.com/teloxide/teloxide-core/pull/102
+
 ## 0.3.0 - 2021-07-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = [
     "Temirkhan Myrzamadi <hirrolot@gmail.com>",

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -14,7 +14,10 @@
 /// [`AutoSend`]: auto_send::AutoSend
 /// [`send`]: crate::requests::Request::send
 #[cfg(feature = "auto_send")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "auto_send")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "auto_send"))
+)]
 pub mod auto_send;
 
 /// [`CacheMe`] bot adaptor which caches [`GetMe`] requests.
@@ -22,7 +25,10 @@ pub mod auto_send;
 /// [`CacheMe`]: cache_me::CacheMe
 /// [`GetMe`]: crate::payloads::GetMe
 #[cfg(feature = "cache_me")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cache_me")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "cache_me"))
+)]
 pub mod cache_me;
 
 /// [`Throttle`] bot adaptor which allows automatically throttle when hitting
@@ -30,19 +36,31 @@ pub mod cache_me;
 ///
 /// [`Throttle`]: throttle::Throttle
 #[cfg(feature = "throttle")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "throttle")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "throttle"))
+)]
 pub mod throttle;
 
 mod parse_mode;
 
 #[cfg(feature = "auto_send")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "auto_send")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "auto_send"))
+)]
 pub use auto_send::AutoSend;
 #[cfg(feature = "cache_me")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cache_me")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "cache_me"))
+)]
 pub use cache_me::CacheMe;
 #[cfg(feature = "throttle")]
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "throttle")))]
+#[cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    doc(cfg(feature = "throttle"))
+)]
 pub use throttle::Throttle;
 
 pub use parse_mode::DefaultParseMode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,13 @@
 // ```console
 // $ RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo doc --open --all-features
 // ```
-#![cfg_attr(all(docsrs, feature = "nightly"), feature(doc_cfg, doc_notable_trait))]
+//
+// `dep_docsrs` is used for the same purpose, but when `teloxide-core` is built as a dependency
+// (see: `teloxide`). We can't use `docsrs` as it breaks tokio compilation in this case.
+#![cfg_attr(
+    all(any(docsrs, dep_docsrs), feature = "nightly"),
+    feature(doc_cfg, doc_notable_trait)
+)]
 #![cfg_attr(feature = "nightly", feature(min_type_alias_impl_trait))]
 #![cfg_attr(all(feature = "full", docsrs), deny(rustdoc::broken_intra_doc_links))]
 //#![deny(missing_docs)]

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -5,7 +5,7 @@
 ///
 /// Also, this trait provides some additional information needed to send a
 /// request to Telegram.
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(notable_trait))]
+#[cfg_attr(all(any(docsrs, dep_docsrs), feature = "nightly"), doc(notable_trait))]
 pub trait Payload {
     /// The return type of a Telegram method.
     ///

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -16,7 +16,7 @@ use crate::requests::{HasPayload, Output};
 /// `B::send_ref` while _not_ meaning to really send the request at the moment.
 ///
 /// [`Throttle<B>`]: crate::adaptors::Throttle
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(notable_trait))]
+#[cfg_attr(all(any(docsrs, dep_docsrs), feature = "nightly"), doc(notable_trait))]
 pub trait Request: HasPayload {
     /*
      * Could be mostly `core::future::IntoFuture` though there is no reason to

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -49,7 +49,7 @@ use crate::{
 ///     bot.send_message(chat, "hi").send().await.expect("error")
 /// }
 /// ```
-#[cfg_attr(all(docsrs, feature = "nightly"), doc(notable_trait))]
+#[cfg_attr(all(any(docsrs, dep_docsrs), feature = "nightly"), doc(notable_trait))]
 pub trait Requester {
     /// Error type returned by all requests.
     type Err: std::error::Error + Send;

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -15,7 +15,10 @@ pub trait RequesterExt: Requester {
     ///
     /// [`CacheMe`]:
     #[cfg(feature = "cache_me")]
-    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "cache_me")))]
+    #[cfg_attr(
+        all(any(docsrs, dep_docsrs), feature = "nightly"),
+        doc(cfg(feature = "cache_me"))
+    )]
     fn cache_me(self) -> CacheMe<Self>
     where
         Self: Sized,
@@ -25,7 +28,10 @@ pub trait RequesterExt: Requester {
 
     /// Send requests automatically, see [`AutoSend`] for more.
     #[cfg(feature = "auto_send")]
-    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "auto_send")))]
+    #[cfg_attr(
+        all(any(docsrs, dep_docsrs), feature = "nightly"),
+        doc(cfg(feature = "auto_send"))
+    )]
     fn auto_send(self) -> AutoSend<Self>
     where
         Self: Sized,
@@ -37,7 +43,10 @@ pub trait RequesterExt: Requester {
     ///
     /// Note: this spawns the worker, just as [`Throttle::new_spawn`].
     #[cfg(feature = "throttle")]
-    #[cfg_attr(all(docsrs, feature = "nightly"), doc(cfg(feature = "throttle")))]
+    #[cfg_attr(
+        all(any(docsrs, dep_docsrs), feature = "nightly"),
+        doc(cfg(feature = "throttle"))
+    )]
     fn throttle(self, limits: Limits) -> Throttle<Self>
     where
         Self: Sized,

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -50,9 +50,6 @@ pub trait RequesterExt: Requester {
     fn throttle(self, limits: Limits) -> Throttle<Self>
     where
         Self: Sized,
-        // >:(
-        // (waffle)
-        Self: 'static,
     {
         Throttle::new_spawn(self, limits)
     }


### PR DESCRIPTION
- Use `cfg(dep_docsrs)` to allow building docs properly as a dependency
- Remove `Self: 'static` bound on `RequesterExt::throttle`
