### PR TITLE
Fix compilation with `nigthly` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## 0.3.3
+
+### Fixed
+
+- Compilation with `nightly` feature (use `type_alias_impl_trait` instead of `min_type_alias_impl_trait`) ([#108][pr108])
+
+[pr108]: https://github.com/teloxide/teloxide-core/pull/108
+
 ## 0.3.2 - 2021-07-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 authors = [
     "Temirkhan Myrzamadi <hirrolot@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! - `full` — enables all features except `nigthly`
 //! - `nightly` — enables nigthly-only features, currently:
 //!   - Removes some future boxing using `#![feature(type_alias_impl_trait)]`
-//!   - Used to built docs (`#![feature(doc_cfg, doc_spotlight)]`)
+//!   - Used to built docs (`#![feature(doc_cfg, doc_notable_trait)]`)
 //!
 //! [`AutoSend`]: adaptors::AutoSend
 //! [`Trace`]: adaptors::Trace
@@ -83,7 +83,7 @@
     all(any(docsrs, dep_docsrs), feature = "nightly"),
     feature(doc_cfg, doc_notable_trait)
 )]
-#![cfg_attr(feature = "nightly", feature(min_type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 #![cfg_attr(all(feature = "full", docsrs), deny(rustdoc::broken_intra_doc_links))]
 //#![deny(missing_docs)]
 


### PR DESCRIPTION
The `min_type_alias_impl_trait` feature was removed in faviour of `type_alias_impl_trait`.

The problem was noticed in https://github.com/teloxide/teloxide/pull/421/checks?check_run_id=3214192304.