### PR TITLE
Fixed message's URLs for private chats and a typo

### DIFF
--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1010,7 +1010,11 @@ impl Message {
             Some(username) => format!("https://t.me/{0}/{1}/", username, self.id),
             // For private groups we produce "private" t.me/c links. These are only
             // accesible to the group members.
-            None => format!("https://t.me/c/{0}/{1}/", &self.chat.id.to_string()[4..], self.id),
+            None => format!(
+                "https://t.me/c/{0}/{1}/",
+                &self.chat.id.to_string()[4..],
+                self.id
+            ),
         };
 
         // UNWRAP:

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -989,7 +989,7 @@ mod getters {
 impl Message {
     /// Produces a direct link to the message.
     ///
-    /// Note that for private groups the link will only be accesible for group
+    /// Note that for private groups the link will only be accessible for group
     /// members.
     ///
     /// Returns `None` for private chats (i.e.: DMs).
@@ -1006,10 +1006,10 @@ impl Message {
 
         let url = match self.chat.username() {
             // If it's public group (i.e. not DM, not private group), we can produce
-            // "normal" t.me link (accesible to everyone).
+            // "normal" t.me link (accessible to everyone).
             Some(username) => format!("https://t.me/{0}/{1}/", username, self.id),
             // For private groups we produce "private" t.me/c links. These are only
-            // accesible to the group members.
+            // accessible to the group members.
             None => format!(
                 "https://t.me/c/{0}/{1}/",
                 (-self.chat.id) - 1000000000000,

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1000,7 +1000,7 @@ impl Message {
             // There are "tg://openmessage?user_id={0}&message_id={1}" links, which are
             // supposed to open any chat, including private messages, but they
             // are only supported by some telegram clients (e.g. Plus Messenger,
-            // Telegram for Androud 4.9+).
+            // Telegram for Android 4.9+).
             return None;
         }
 
@@ -1010,7 +1010,7 @@ impl Message {
             Some(username) => format!("https://t.me/{0}/{1}/", username, self.id),
             // For private groups we produce "private" t.me/c links. These are only
             // accesible to the group members.
-            None => format!("https://t.me/c/{0}/{1}/", self.chat.id, self.id),
+            None => format!("https://t.me/c/{0}/{1}/", &self.chat.id.to_string()[4..], self.id),
         };
 
         // UNWRAP:

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -1012,7 +1012,7 @@ impl Message {
             // accesible to the group members.
             None => format!(
                 "https://t.me/c/{0}/{1}/",
-                &self.chat.id.to_string()[4..],
+                (-self.chat.id) - 1000000000000,
                 self.id
             ),
         };


### PR DESCRIPTION
Message's URLs don't use the whole chat id, they remove the prefix (-100)