### PR TITLE
Fix type of `Poll::{correct_option_id,open_period}` fields: `i32` => `u8` and `u16`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Type of `BanChatMember::until_date`: `u64` -> `chrono::DateTime<Utc>` ([#116][pr116])
+- Type of `Poll::correct_option_id`: `i32` -> `u8` ([#119][pr119])
+- Type of `Poll::open_period`: `i32` -> `u16` ([#119][pr119])
 
 ## 0.3.3 - 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type of `Poll::correct_option_id`: `i32` -> `u8` ([#119][pr119])
 - Type of `Poll::open_period`: `i32` -> `u16` ([#119][pr119])
 
+[pr119]: https://github.com/teloxide/teloxide-core/pull/119
 ## 0.3.3 - 2021-08-03
 
 ### Fixed

--- a/src/types/poll.rs
+++ b/src/types/poll.rs
@@ -48,7 +48,7 @@ pub struct Poll {
     pub explanation_entities: Option<Vec<MessageEntity>>,
 
     /// Amount of time in seconds the poll will be active after creation.
-    pub open_period: Option<i32>,
+    pub open_period: Option<u16>,
 
     /// Point in time when the poll will be automatically closed.
     #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]

--- a/src/types/poll.rs
+++ b/src/types/poll.rs
@@ -37,7 +37,7 @@ pub struct Poll {
     /// 0-based identifier of the correct answer option. Available only for
     /// polls in the quiz mode, which are closed, or was sent (not
     /// forwarded) by the bot or to the private chat with the bot.
-    pub correct_option_id: Option<i32>,
+    pub correct_option_id: Option<u8>,
 
     /// Text that is shown when a user chooses an incorrect answer or taps on
     /// the lamp icon in a quiz-style poll, 0-200 characters.


### PR DESCRIPTION
Params [correct_option_id](https://github.com/WaffleLapkin/tg-methods-schema/blob/b7e0ddbde7a8f3a53720531370f49b51c73e295f/schema.ron#L1517) and [open_period](https://github.com/WaffleLapkin/tg-methods-schema/blob/b7e0ddbde7a8f3a53720531370f49b51c73e295f/schema.ron#L1541) of `sendPoll` method use smaller types, because `correct_option_id` is in the range 0..9 and fits in u8, and `open_period` in the range 5..600 can be u16. As I understand it, this is just a typo mistake.