### PR TITLE
Remove explicit `doc(cfg)` as it's now implied

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -14,10 +14,6 @@
 /// [`AutoSend`]: auto_send::AutoSend
 /// [`send`]: crate::requests::Request::send
 #[cfg(feature = "auto_send")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "auto_send"))
-)]
 pub mod auto_send;
 
 /// [`CacheMe`] bot adaptor which caches [`GetMe`] requests.
@@ -25,20 +21,12 @@ pub mod auto_send;
 /// [`CacheMe`]: cache_me::CacheMe
 /// [`GetMe`]: crate::payloads::GetMe
 #[cfg(feature = "cache_me")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "cache_me"))
-)]
 pub mod cache_me;
 
 /// [`Trace`] bot adaptor which traces requests.
 ///
 /// [`Trace`]: trace::Trace
 #[cfg(feature = "trace_adaptor")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "trace_adaptor"))
-)]
 pub mod trace;
 
 /// [`ErasedRequester`] bot adaptor which allows to erase type of
@@ -47,10 +35,6 @@ pub mod trace;
 /// [`ErasedRequester`]: erased::ErasedRequester
 /// [`Requester`]: crate::requests::Requester
 #[cfg(feature = "erased")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "erased"))
-)]
 pub mod erased;
 
 /// [`Throttle`] bot adaptor which allows automatically throttle when hitting
@@ -58,43 +42,19 @@ pub mod erased;
 ///
 /// [`Throttle`]: throttle::Throttle
 #[cfg(feature = "throttle")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "throttle"))
-)]
 pub mod throttle;
 
 mod parse_mode;
 
 #[cfg(feature = "auto_send")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "auto_send"))
-)]
 pub use auto_send::AutoSend;
 #[cfg(feature = "cache_me")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "cache_me"))
-)]
 pub use cache_me::CacheMe;
 #[cfg(feature = "erased")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "erased"))
-)]
 pub use erased::ErasedRequester;
 #[cfg(feature = "throttle")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "throttle"))
-)]
 pub use throttle::Throttle;
 #[cfg(feature = "trace_adaptor")]
-#[cfg_attr(
-    all(any(docsrs, dep_docsrs), feature = "nightly"),
-    doc(cfg(feature = "trace_adaptor"))
-)]
 pub use trace::Trace;
 
 pub use parse_mode::DefaultParseMode;

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -18,13 +18,7 @@ use crate::adaptors::throttle::{Limits, Throttle};
 /// Extensions methods for [`Requester`].
 pub trait RequesterExt: Requester {
     /// Add `get_me` caching ability, see [`CacheMe`] for more.
-    ///
-    /// [`CacheMe`]:
     #[cfg(feature = "cache_me")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "cache_me"))
-    )]
     fn cache_me(self) -> CacheMe<Self>
     where
         Self: Sized,
@@ -34,10 +28,6 @@ pub trait RequesterExt: Requester {
 
     /// Send requests automatically, see [`AutoSend`] for more.
     #[cfg(feature = "auto_send")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "auto_send"))
-    )]
     fn auto_send(self) -> AutoSend<Self>
     where
         Self: Sized,
@@ -47,10 +37,6 @@ pub trait RequesterExt: Requester {
 
     /// Erase requester type.
     #[cfg(feature = "erased")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "erased"))
-    )]
     fn erase<'a>(self) -> ErasedRequester<'a, Self::Err>
     where
         Self: 'a,
@@ -61,10 +47,6 @@ pub trait RequesterExt: Requester {
 
     /// Trace requests, see [`Trace`] for more.
     #[cfg(feature = "trace_adaptor")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "trace_adaptor"))
-    )]
     fn trace(self, settings: Settings) -> Trace<Self>
     where
         Self: Sized,
@@ -76,10 +58,6 @@ pub trait RequesterExt: Requester {
     ///
     /// Note: this spawns the worker, just as [`Throttle::new_spawn`].
     #[cfg(feature = "throttle")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "throttle"))
-    )]
     fn throttle(self, limits: Limits) -> Throttle<Self>
     where
         Self: Sized,


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/89596 is merged, `doc(cfg)` is now implied.