### PR TITLE
Add `#[must_use]` attrs to payload setters, request wrappers and send* methods

### DIFF
--- a/src/adaptors/auto_send.rs
+++ b/src/adaptors/auto_send.rs
@@ -116,6 +116,7 @@ download_forward! {
     { this => this.inner() }
 }
 
+#[must_use = "Futures are lazy and do nothing unless polled or awaited"]
 #[pin_project::pin_project]
 pub struct AutoRequest<R: Request>(#[pin] Inner<R>);
 

--- a/src/adaptors/cache_me.rs
+++ b/src/adaptors/cache_me.rs
@@ -123,6 +123,7 @@ download_forward! {
     { this => this.inner() }
 }
 
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct CachedMeRequest<R: Request<Payload = GetMe>>(Inner<R>, GetMe);
 
 enum Inner<R: Request<Payload = GetMe>> {

--- a/src/adaptors/erased.rs
+++ b/src/adaptors/erased.rs
@@ -35,6 +35,7 @@ impl<'a, E> ErasedRequester<'a, E> {
 }
 
 /// [`Request`] with erased type.
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct ErasedRequest<'a, T, E> {
     inner: Box<dyn ErasableRequest<'a, Payload = T, Err = E> + 'a>,
 }

--- a/src/adaptors/throttle.rs
+++ b/src/adaptors/throttle.rs
@@ -663,6 +663,7 @@ impl From<&ChatId> for ChatIdHash {
     }
 }
 
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct ThrottlingRequest<R: HasPayload> {
     request: R,
     chat_id: fn(&R::Payload) -> ChatIdHash,

--- a/src/adaptors/trace.rs
+++ b/src/adaptors/trace.rs
@@ -141,6 +141,7 @@ where
     }
 }
 
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct TraceRequest<R> {
     inner: R,
     settings: Settings,

--- a/src/local_macros.rs
+++ b/src/local_macros.rs
@@ -255,6 +255,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field<T>(mut self, value: T) -> Self
             where
                 T: Into<$FTy>,
@@ -276,6 +277,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field<T>(mut self, value: T) -> Self
             where
                 T: ::core::iter::IntoIterator<Item = <$FTy as ::core::iter::IntoIterator>::Item>,
@@ -297,6 +299,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field(mut self, value: $FTy) -> Self {
                 self.payload_mut().$field = Some(value);
                 self
@@ -315,6 +318,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field<T>(mut self, value: T) -> Self
             where
                 T: Into<$FTy>,
@@ -336,6 +340,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field<T>(mut self, value: T) -> Self
             where
                 T: ::core::iter::IntoIterator<Item = <$FTy as ::core::iter::IntoIterator>::Item>,
@@ -357,6 +362,7 @@ macro_rules! impl_payload {
                 ") field."
             )]
             #[allow(clippy::wrong_self_convention)]
+            #[must_use = "Payloads and requests do nothing unless sent"]
             fn $field(mut self, value: $FTy) -> Self {
                 self.payload_mut().$field = value;
                 self

--- a/src/requests/json.rs
+++ b/src/requests/json.rs
@@ -9,7 +9,7 @@ use crate::{
 /// A ready-to-send Telegram request whose payload is sent using [JSON].
 ///
 /// [JSON]: https://core.telegram.org/bots/api#making-requests
-#[must_use = "requests do nothing until sent"]
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct JsonRequest<P> {
     bot: Bot,
     payload: P,

--- a/src/requests/multipart.rs
+++ b/src/requests/multipart.rs
@@ -10,7 +10,7 @@ use crate::{
 /// [multipart/form-data].
 ///
 /// [multipart/form-data]: https://core.telegram.org/bots/api#making-requests
-#[must_use = "requests do nothing until sent"]
+#[must_use = "Requests are lazy and do nothing unless sent"]
 pub struct MultipartRequest<P> {
     bot: Bot,
     payload: P,

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -59,6 +59,7 @@ pub trait Request: HasPayload {
     /// let _: Me = request.send().await.unwrap();
     /// # };
     /// ```
+    #[must_use = "Futures are lazy and do nothing unless polled or awaited"]
     fn send(self) -> Self::Send;
 
     /// Send this request by reference.
@@ -86,13 +87,10 @@ pub trait Request: HasPayload {
     /// }
     /// # };
     /// ```
+    #[must_use = "Futures are lazy and do nothing unless polled or awaited"]
     fn send_ref(&self) -> Self::SendRef;
 
     #[cfg(feature = "erased")]
-    #[cfg_attr(
-        all(any(docsrs, dep_docsrs), feature = "nightly"),
-        doc(cfg(feature = "erased"))
-    )]
     fn erase<'a>(self) -> crate::adaptors::erased::ErasedRequest<'a, Self::Payload, Self::Err>
     where
         Self: Sized + 'a,


### PR DESCRIPTION
See #453

With this, the only way to not get a warning while writing code that doesn't send requests is to use generic `Requester` and do not use optional params or `send*` methods:
```rust
pub async fn test(bot: impl Requester) {
     bot.send_chat_action(0, ChatAction::Typing);
}
```