### PR TITLE
Disable default features of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ mime = "0.3.16"
 thiserror = "1.0.20"
 once_cell = "1.5.0"
 never = "0.1.0"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false }
 either = "1.6.1"
 
 vecrem = { version = "0.1", optional = true }


### PR DESCRIPTION
This removes an unnecessary dependency on time 0.1