### PR TITLE
fix: Add missing derive(Debug) on adapters

### DIFF
--- a/src/adaptors/auto_send.rs
+++ b/src/adaptors/auto_send.rs
@@ -38,7 +38,7 @@ use crate::{
 /// let myself: Me = bot.get_me().await?; // No .send()!
 /// # Ok::<_, teloxide_core::RequestError>(()) };
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AutoSend<B> {
     bot: B,
 }

--- a/src/adaptors/cache_me.rs
+++ b/src/adaptors/cache_me.rs
@@ -19,7 +19,7 @@ use crate::{
 ///
 /// Bot's user is hardly ever changed, so sometimes it's reasonable to cache
 /// response from `get_me` method.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CacheMe<B> {
     bot: B,
     me: Arc<OnceCell<Me>>,

--- a/src/adaptors/erased.rs
+++ b/src/adaptors/erased.rs
@@ -34,6 +34,12 @@ impl<'a, E> ErasedRequester<'a, E> {
     }
 }
 
+impl<E> std::fmt::Debug for ErasedRequester<'_, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("ErasedRequester").finish_non_exhaustive()
+    }
+}
+
 /// [`Request`] with erased type.
 pub struct ErasedRequest<'a, T, E> {
     inner: Box<dyn ErasableRequest<'a, Payload = T, Err = E> + 'a>,

--- a/src/adaptors/parse_mode.rs
+++ b/src/adaptors/parse_mode.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// Default parse mode adaptor, see
 /// [`RequesterExt::parse_mode`](crate::requests::RequesterExt::parse_mode).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DefaultParseMode<B> {
     bot: B,
     mode: ParseMode,

--- a/src/adaptors/throttle.rs
+++ b/src/adaptors/throttle.rs
@@ -63,7 +63,7 @@ use crate::{
 ///
 /// As such, we encourage not to use `ChatId::ChannelUsername(u)` with this bot
 /// wrapper.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Throttle<B> {
     bot: B,
     // `RequestLock` allows to unlock requests (allowing them to be sent).

--- a/src/adaptors/trace.rs
+++ b/src/adaptors/trace.rs
@@ -25,7 +25,7 @@ use crate::{
 /// TRACE teloxide_core::adaptors::trace > Sending `SendDice` request: SendDice { chat_id: Id(0), emoji: Some(Dice), disable_notification: None, reply_to_message_id: None, allow_sending_without_reply: None, reply_markup: None }
 /// TRACE teloxide_core::adaptors::trace > Got response from `SendDice` request: Ok(Message { id: 13812, date: 1625926524, chat: Chat { .. }, via_bot: None, kind: Dice(MessageDice { dice: Dice { emoji: Dice, value: 3 } }) })
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Trace<B> {
     inner: B,
     settings: Settings,


### PR DESCRIPTION
As discussed in the chat, these derives from the main Bot are missing on the adapters making them incompatible.