### PR TITLE
Enable clippy to warn on dbg/print usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,7 @@
 #![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 #![cfg_attr(all(feature = "full", docsrs), deny(rustdoc::broken_intra_doc_links))]
 //#![deny(missing_docs)]
-
-// https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
+#![warn(clippy::print_stdout, clippy::dbg_macro)]
 
 // The internal helper macros.
 #[macro_use]


### PR DESCRIPTION
We've previously released a version of `teloxide-core` that had `dbg!` in it, so it seems like a good idea to enable these warnings to prevent this from happening again.

Also, remove an old `#![allow]` that was used to suppress a Clippy bug that has been fixed since then.
