### PR TITLE
Add the missing field `media_group_id` to `MediaDocument` & `MediaAudio`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EditedMessageIsTooLong` error ([#109][pr109])
 - `UntilDate` enum and use it for `{Restricted, Banned}::until_date` ([#116][pr116])
 - `Limits::messages_per_min_channel` ([#121][pr121])
+- `media_group_id` field to `MediaDocument` and `MediaAudio` ([#139][pr139])
 
 [pr109]: https://github.com/teloxide/teloxide-core/pull/109
 [pr116]: https://github.com/teloxide/teloxide-core/pull/116
 [pr121]: https://github.com/teloxide/teloxide-core/pull/121
 [pr135]: https://github.com/teloxide/teloxide-core/pull/135
+[pr139]: https://github.com/teloxide/teloxide-core/pull/139
 
 ### Changed
 

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -319,6 +319,10 @@ pub struct MediaAudio {
     /// bot commands, etc. that appear in the caption.
     #[serde(default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
+
+    /// The unique identifier of a media message group this message belongs
+    /// to.
+    pub media_group_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -340,6 +344,10 @@ pub struct MediaDocument {
     /// bot commands, etc. that appear in the caption.
     #[serde(default = "Vec::new")]
     pub caption_entities: Vec<MessageEntity>,
+
+    /// The unique identifier of a media message group this message belongs
+    /// to.
+    pub media_group_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -619,6 +627,14 @@ mod getters {
                 })
                 | Common(MessageCommon {
                     media_kind: MediaKind::Photo(MediaPhoto { media_group_id, .. }),
+                    ..
+                })
+                | Common(MessageCommon {
+                    media_kind: MediaKind::Document(MediaDocument { media_group_id, .. }),
+                    ..
+                })
+                | Common(MessageCommon {
+                    media_kind: MediaKind::Audio(MediaAudio { media_group_id, .. }),
                     ..
                 }) => media_group_id.as_ref().map(Deref::deref),
                 _ => None,


### PR DESCRIPTION
According to the `media` argument type of [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup) method, we can know that these media may be sent in a group: `MediaAudio`, `MediaDocument`, `MediaPhoto`, `MediaVideo`.

You can also send a group of files or audios to [@JsonDumpBot](https://t.me/JsonDumpBot) and you can see the `media_group_id` field in the json dump of the reply.

This PR added the missing field `media_group_id` to struct `MediaDocument` and struct `MediaAudio`.