### PR TITLE
Add the missing method `caption_entities` to `InputMediaPhoto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UntilDate` enum and use it for `{Restricted, Banned}::until_date` ([#116][pr116])
 - `Limits::messages_per_min_channel` ([#121][pr121])
 - `media_group_id` field to `MediaDocument` and `MediaAudio` ([#139][pr139])
+- `caption_entities` method to `InputMediaPhoto` ([#140][pr140])
 
 [pr109]: https://github.com/teloxide/teloxide-core/pull/109
 [pr116]: https://github.com/teloxide/teloxide-core/pull/116
 [pr121]: https://github.com/teloxide/teloxide-core/pull/121
 [pr135]: https://github.com/teloxide/teloxide-core/pull/135
 [pr139]: https://github.com/teloxide/teloxide-core/pull/139
+[pr140]: https://github.com/teloxide/teloxide-core/pull/140
 
 ### Changed
 

--- a/src/types/input_media.rs
+++ b/src/types/input_media.rs
@@ -68,6 +68,14 @@ impl InputMediaPhoto {
         self.parse_mode = Some(val);
         self
     }
+
+    pub fn caption_entities<C>(mut self, val: C) -> Self
+    where
+        C: IntoIterator<Item = MessageEntity>,
+    {
+        self.caption_entities = Some(val.into_iter().collect());
+        self
+    }
 }
 
 /// Represents a video to be sent.


### PR DESCRIPTION
The docs of `ImputMediaPhoto`: https://core.telegram.org/bots/api#inputmediaphoto