### PR TITLE
Fix the incorrect response type of `CopyMessage` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Throttle` adaptor not honouring chat/min limits ([#121][pr121])
 - Make `SendPoll::poll_` optional ([#133][pr133])
 - Bug with `caption_entities`, see issue [#473][issue473]
+- Type of response for `CopyMessage` method ([#141](pr141))
 
 [pr119]: https://github.com/teloxide/teloxide-core/pull/119
 [pr133]: https://github.com/teloxide/teloxide-core/pull/133
+[pr141]: https://github.com/teloxide/teloxide-core/pull/141
 [issue473]: https://github.com/teloxide/teloxide/issues/473
 
 ## 0.3.3 - 2021-08-03

--- a/src/types/message_id.rs
+++ b/src/types/message_id.rs
@@ -1,4 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// This object represents a unique message identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageId {
     /// Unique message identifier
     pub message_id: i32,


### PR DESCRIPTION
MRE:
```rust
use teloxide::prelude::*;

#[tokio::main]
async fn main() {
    let bot = Bot::from_env().auto_send();

    teloxide::repl(bot, |cx| async move {
        cx.requester
            .copy_message(cx.update.chat_id(), cx.update.chat_id(), cx.update.id)
            .send()
            .await
            .unwrap();

        respond(())
    })
    .await;
}
```

unwrap panic:
```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidJson(Error("data did not match any variant of untagged enum TelegramResponse", line: 0, column: 0))', src\main.rs:12:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

response:
```json
{"ok":true,"result":{"message_id":123}}
```

The docs of `copyMessage` method: https://core.telegram.org/bots/api#copymessage