### PR TITLE
Skip the `language` field of `MessageEntityKind::Pre` if it is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `SendPoll::poll_` optional ([#133][pr133])
 - Bug with `caption_entities`, see issue [#473][issue473]
 - Type of response for `CopyMessage` method ([#141](pr141), [#142](pr142))
+- Bad request serialization when the `language` field of `MessageEntityKind::Pre` is `None` ([#145](pr145))
 
 [pr119]: https://github.com/teloxide/teloxide-core/pull/119
 [pr133]: https://github.com/teloxide/teloxide-core/pull/133
 [pr141]: https://github.com/teloxide/teloxide-core/pull/141
 [pr142]: https://github.com/teloxide/teloxide-core/pull/142
 [pr143]: https://github.com/teloxide/teloxide-core/pull/143
+[pr145]: https://github.com/teloxide/teloxide-core/pull/145
 [issue473]: https://github.com/teloxide/teloxide/issues/473
 [issue427]: https://github.com/teloxide/teloxide/issues/427
 

--- a/src/types/message_entity.rs
+++ b/src/types/message_entity.rs
@@ -44,6 +44,7 @@ impl MessageEntity {
     }
 }
 
+#[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
@@ -102,6 +103,22 @@ mod tests {
             },
             from_str::<MessageEntity>(r#"{"type":"pre","offset":1,"length":2,"language":"rust"}"#)
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn pre_with_none_language() {
+        use serde_json::to_string;
+
+        assert_eq!(
+            to_string(&MessageEntity {
+                kind: MessageEntityKind::Pre { language: None },
+                offset: 1,
+                length: 2,
+            })
+            .unwrap()
+            .find("language"),
+            None
         );
     }
 }

--- a/src/types/message_entity.rs
+++ b/src/types/message_entity.rs
@@ -106,6 +106,7 @@ mod tests {
         );
     }
 
+    // https://github.com/teloxide/teloxide-core/pull/145
     #[test]
     fn pre_with_none_language() {
         use serde_json::to_string;


### PR DESCRIPTION
MRE:

```rust
use teloxide::{
    payloads::SendMessageSetters,
    prelude::*,
    types::{MessageEntity, MessageEntityKind},
};

#[tokio::main]
async fn main() {
    let bot = Bot::from_env().auto_send();

    teloxide::repl(bot, |cx| async move {
        let entity = MessageEntity::new(MessageEntityKind::Pre { language: None }, 0, 4);

        println!("{}\n", serde_json::to_string(&entity).unwrap());

        cx.requester
            .send_message(cx.update.chat_id(), "test")
            .entities(vec![entity])
            .await
            .unwrap();

        respond(())
    })
    .await;
}
```

unwrap panic:
```
{"type":"pre","language":null,"offset":0,"length":4}

thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: ApiError { kind: Unknown("Bad Request: can't parse MessageEntity: Field \"language\" must be of type String"), status_code: 400 }', src\main.rs:20:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The `language` field should be skipped if it is `None`, this PR fixed it.