### PR TITLE
Fix serialization of `BotCommandScope::Chat{,Administrators}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bad request serialization when the `language` field of `MessageEntityKind::Pre` is `None` ([#145](pr145))
 - Deserialization of `MediaKind::Venue` ([#147][pr147])
 - Deserialization of `VoiceChat{Started,Ended}` messages ([#153][pr153])
+- Serialization of `BotCommandScope::Chat{,Administrators}` ([#154][pr154])
 
 [pr119]: https://github.com/teloxide/teloxide-core/pull/119
 [pr133]: https://github.com/teloxide/teloxide-core/pull/133
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [pr145]: https://github.com/teloxide/teloxide-core/pull/145
 [pr147]: https://github.com/teloxide/teloxide-core/pull/147
 [pr153]: https://github.com/teloxide/teloxide-core/pull/153
+[pr154]: https://github.com/teloxide/teloxide-core/pull/154
 [issue473]: https://github.com/teloxide/teloxide/issues/473
 [issue427]: https://github.com/teloxide/teloxide/issues/427
 

--- a/src/types/bot_command_scope.rs
+++ b/src/types/bot_command_scope.rs
@@ -49,7 +49,20 @@ pub enum BotCommandScope {
     AllPrivateChats,
     AllGroupChats,
     AllChatAdministrators,
-    Chat(#[serde(rename = "chat_id")] ChatId),
-    ChatAdministrators(#[serde(rename = "chat_id")] ChatId),
+    Chat { chat_id: ChatId },
+    ChatAdministrators { chat_id: ChatId },
     ChatMember { chat_id: ChatId, user_id: i64 },
+}
+
+#[test]
+fn issue_486() {
+    serde_json::to_string(&BotCommandScope::Chat {
+        chat_id: ChatId::Id(0),
+    })
+    .unwrap();
+
+    serde_json::to_string(&BotCommandScope::ChatAdministrators {
+        chat_id: ChatId::Id(0),
+    })
+    .unwrap();
 }


### PR DESCRIPTION
Fixes https://github.com/teloxide/teloxide/issues/486

Welp, I should have tested that `#[serde(rename)]` worked like I thought it did.