### PR TITLE
Fix deserializing `Document`

### DIFF
--- a/src/serde_multipart/mod.rs
+++ b/src/serde_multipart/mod.rs
@@ -31,6 +31,7 @@ pub(crate) fn to_form<T: ?Sized + Serialize>(val: &T) -> impl Future<Output = Re
 }
 
 // https://github.com/teloxide/teloxide/issues/473
+#[cfg(test)]
 #[tokio::test]
 async fn issue_473() {
     use crate::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -245,16 +245,11 @@ pub(crate) mod serde_opt_date_from_unix_timestamp {
             .map(|timestamp| DateTime::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc)))
     }
 
-    pub(crate) fn none<T>() -> Option<T> {
-        None
-    }
-
     #[test]
     fn test() {
         #[derive(Serialize, Deserialize)]
         struct Struct {
-            #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]
-            #[serde(default = "crate::types::serde_opt_date_from_unix_timestamp::none")]
+            #[serde(default, with = "crate::types::serde_opt_date_from_unix_timestamp")]
             date: Option<DateTime<Utc>>,
         }
 

--- a/src/types/chat_invite_link.rs
+++ b/src/types/chat_invite_link.rs
@@ -21,8 +21,7 @@ pub struct ChatInviteLink {
     pub name: Option<String>,
     /// Point in time when the link will expire or has been
     /// expired
-    #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]
-    #[serde(default = "crate::types::serde_opt_date_from_unix_timestamp::none")]
+    #[serde(default, with = "crate::types::serde_opt_date_from_unix_timestamp")]
     pub expire_date: Option<DateTime<Utc>>,
     /// Maximum number of users that can be members of the chat simultaneously
     /// after joining the chat via this invite link; 1-99999

--- a/src/types/document.rs
+++ b/src/types/document.rs
@@ -29,7 +29,7 @@ pub struct Document {
     pub file_name: Option<String>,
 
     /// A MIME type of the file as defined by a sender.
-    #[serde(with = "crate::types::non_telegram_types::mime::opt_deser")]
+    #[serde(default, with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
     /// A size of a file.

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -363,7 +363,7 @@ pub struct MediaDocument {
 
     /// For messages with a caption, special entities like usernames, URLs,
     /// bot commands, etc. that appear in the caption.
-    #[serde(default = "Vec::new")]
+    #[serde(default)]
     pub caption_entities: Vec<MessageEntity>,
 
     /// The unique identifier of a media message group this message belongs

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -85,8 +85,7 @@ pub struct MessageCommon {
     pub reply_to_message: Option<Box<Message>>,
 
     /// Date the message was last edited in Unix time.
-    #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]
-    #[serde(default = "crate::types::serde_opt_date_from_unix_timestamp::none")]
+    #[serde(default, with = "crate::types::serde_opt_date_from_unix_timestamp")]
     pub edit_date: Option<DateTime<Utc>>,
 
     #[serde(flatten)]

--- a/src/types/poll.rs
+++ b/src/types/poll.rs
@@ -51,8 +51,7 @@ pub struct Poll {
     pub open_period: Option<u16>,
 
     /// Point in time when the poll will be automatically closed.
-    #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]
-    #[serde(default = "crate::types::serde_opt_date_from_unix_timestamp::none")]
+    #[serde(default, with = "crate::types::serde_opt_date_from_unix_timestamp")]
     pub close_date: Option<DateTime<Utc>>,
 }
 

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -22,8 +22,7 @@ pub struct WebhookInfo {
 
     /// Time of the most recent error that happened when trying to
     /// deliver an update via webhook.
-    #[serde(with = "crate::types::serde_opt_date_from_unix_timestamp")]
-    #[serde(default = "crate::types::serde_opt_date_from_unix_timestamp::none")]
+    #[serde(default, with = "crate::types::serde_opt_date_from_unix_timestamp")]
     pub last_error_date: Option<DateTime<Utc>>,
 
     /// Error message in human-readable format for the most recent error that


### PR DESCRIPTION
When calling `Bot::send_document`, I get an error: `InvalidJson(Error("data did not match any variant of untagged enum TelegramResponse", line: 0, column: 0))`.
Also, when compiling my app with freshly cloned teloxide-core, I got compilation error (see the 1st commit).
This PR fixes both problems.