### PR TITLE
Fix `doc(cfg)` implication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 // (see: `teloxide`). We can't use `docsrs` as it breaks tokio compilation in this case.
 #![cfg_attr(
     all(any(docsrs, dep_docsrs), feature = "nightly"),
-    feature(doc_cfg, doc_notable_trait)
+    feature(doc_cfg, doc_auto_cfg, doc_notable_trait)
 )]
 #![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 #![cfg_attr(all(feature = "full", docsrs), deny(rustdoc::broken_intra_doc_links))]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/90502 split `doc_cfg` feature into two, the implication of `doc(cfg)` by `cfg` now depends on `doc_auto_cfg` feature.