### PR TITLE
fix issue with WebhookInfo not parsing correctly

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -329,7 +329,7 @@ pub(crate) mod option_url_from_string {
             assert_eq!(url.url, None);
             assert_eq!(
                 serde_json::to_string(&url).unwrap(),
-                r#"{"url":""}"#.to_string()
+                json.to_owned()
             );
 
             let json = r#"{"url":"https://github.com/token"}"#;
@@ -340,7 +340,7 @@ pub(crate) mod option_url_from_string {
             );
             assert_eq!(
                 serde_json::to_string(&url).unwrap(),
-                r#"{"url":"https://github.com/token"}"#.to_string()
+                json.to_owned()
             );
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -301,7 +301,10 @@ pub(crate) mod option_url_from_string {
     where
         S: Serializer,
     {
-        this.serialize(serializer)
+        match this {
+            Some(url) => url.serialize(serializer),
+            None => "".serialize(serializer),
+        }
     }
 
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
@@ -322,14 +325,22 @@ pub(crate) mod option_url_from_string {
 
         {
             let json = r#"{"url":""}"#;
-            let Struct { url } = serde_json::from_str(json).unwrap();
-            assert_eq!(url, None);
+            let url: Struct = serde_json::from_str(json).unwrap();
+            assert_eq!(url.url, None);
+            assert_eq!(
+                serde_json::to_string(&url).unwrap(),
+                r#"{"url":""}"#.to_string()
+            );
 
             let json = r#"{"url":"https://github.com/token"}"#;
-            let Struct { url } = serde_json::from_str(json).unwrap();
+            let url: Struct = serde_json::from_str(json).unwrap();
             assert_eq!(
-                url,
+                url.url,
                 Some(Url::from_str("https://github.com/token").unwrap())
+            );
+            assert_eq!(
+                serde_json::to_string(&url).unwrap(),
+                r#"{"url":"https://github.com/token"}"#.to_string()
             );
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -327,10 +327,7 @@ pub(crate) mod option_url_from_string {
             let json = r#"{"url":""}"#;
             let url: Struct = serde_json::from_str(json).unwrap();
             assert_eq!(url.url, None);
-            assert_eq!(
-                serde_json::to_string(&url).unwrap(),
-                json.to_owned()
-            );
+            assert_eq!(serde_json::to_string(&url).unwrap(), json.to_owned());
 
             let json = r#"{"url":"https://github.com/token"}"#;
             let url: Struct = serde_json::from_str(json).unwrap();
@@ -338,10 +335,7 @@ pub(crate) mod option_url_from_string {
                 url.url,
                 Some(Url::from_str("https://github.com/token").unwrap())
             );
-            assert_eq!(
-                serde_json::to_string(&url).unwrap(),
-                json.to_owned()
-            );
+            assert_eq!(serde_json::to_string(&url).unwrap(), json.to_owned());
         }
     }
 }

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WebhookInfo {
-    #[serde(deserialize_with = "empty_string_to_url")]
+    #[serde(with = "crate::types::option_url_from_string")]
     /// Webhook URL, `None` if webhook is not set up.
     pub url: Option<reqwest::Url>,
 
@@ -37,11 +37,4 @@ pub struct WebhookInfo {
     /// A list of update types the bot is subscribed to. Defaults to all update
     /// types.
     pub allowed_updates: Option<Vec<String>>,
-}
-
-fn empty_string_to_url<'de, D>(deserializer: D) -> Result<Option<reqwest::Url>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    Ok(reqwest::Url::deserialize(deserializer).ok())
 }

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WebhookInfo {
+    #[serde(deserialize_with = "empty_string_to_url")]
     /// Webhook URL, `None` if webhook is not set up.
     pub url: Option<reqwest::Url>,
 
@@ -36,4 +37,11 @@ pub struct WebhookInfo {
     /// A list of update types the bot is subscribed to. Defaults to all update
     /// types.
     pub allowed_updates: Option<Vec<String>>,
+}
+
+fn empty_string_to_url<'de, D>(deserializer: D) -> Result<Option<reqwest::Url>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(reqwest::Url::deserialize(deserializer).ok())
 }

--- a/src/types/webhook_info.rs
+++ b/src/types/webhook_info.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 #[serde_with_macros::skip_serializing_none]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WebhookInfo {
-    #[serde(with = "crate::types::option_url_from_string")]
     /// Webhook URL, `None` if webhook is not set up.
+    #[serde(with = "crate::types::option_url_from_string")]
     pub url: Option<reqwest::Url>,
 
     /// `true`, if a custom certificate was provided for webhook certificate


### PR DESCRIPTION
Currently WebhookInfo fails to parse response like
``` json
{
        "url": "",
        "has_custom_certificate": false,
        "pending_update_count": 0,
        "allowed_updates": [
            "message"
        ]
    }
```
which according to [telegram docs](https://core.telegram.org/bots/api#getwebhookinfo) is expected when webhook is not set.

One approach is to use custom deserialization method. The other is to use `String` instead of `Option<reqwest::Url>`