### PR TITLE
Change process of building docs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+[alias]
+# Using `--features=full --features=nightly` instead of `--all-features` because of
+# https://github.com/rust-lang/cargo/issues/10333
+#
+# "tokio/macros" and "tokio/rt-multi-thread" are required for examples
+docs = """doc
+-Zrustdoc-scrape-examples=examples
+--features=full --features=nightly
+--features=tokio/macros --features=tokio/rt-multi-thread
+"""
+
+# We pass "--cfg docsrs" when building docs to add `This is supported on feature="..." only.`
+rustdocflags = ["--cfg", "docsrs", "-Znormalize-docs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,11 +80,15 @@ cache_me = []
 # AutoSend bot adaptor
 auto_send = []
 
+# All features except nightly and tls-related
 full = ["throttle", "trace_adaptor", "erased", "cache_me", "auto_send"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["full", "nightly", "tokio/macros", "tokio/rt-multi-thread"]
 rustdoc-args = ["--cfg", "docsrs", "-Znormalize-docs"]
+
+# https://github.com/rust-lang/rust/issues/88791
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [[example]]
 name = "self_info"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 [build] 
-command = "rustup install nightly --profile minimal && cargo +nightly doc --all-features --no-deps && cp -r target/doc _netlify_out"
-environment = { RUSTDOCFLAGS= "--cfg docsrs -Znormalize-docs" } 
+command = "rustup install nightly --profile minimal && cargo +nightly docs --no-deps && cp -r target/doc _netlify_out"
 publish = "_netlify_out" 
 
 [[redirects]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! - `erased` — enables [`ErasedRequester`] bot adaptor
 //! - `throttle` — enables [`Throttle`] bot adaptor
 //! - `cache_me` — enables [`CacheMe`] bot adaptor
-//! - `full` — enables all features except `nigthly`
+//! - `full` — enables all features except `nigthly` and tls-related
 //! - `nightly` — enables nigthly-only features, currently:
 //!   - Removes some future boxing using `#![feature(type_alias_impl_trait)]`
 //!   - Used to built docs (`#![feature(doc_cfg, doc_notable_trait)]`)
@@ -74,8 +74,9 @@
 //
 // To properly build docs of this crate run
 // ```console
-// $ RUSTDOCFLAGS="--cfg docsrs -Znormalize-docs" cargo doc --open --all-features
+// $ cargo docs
 // ```
+// (docs alias is defined in `.cargo/config.toml`)
 //
 // `dep_docsrs` is used for the same purpose, but when `teloxide-core` is built as a dependency
 // (see: `teloxide`). We can't use `docsrs` as it breaks tokio compilation in this case.


### PR DESCRIPTION
- introduce `docs` alias that does the right thing (tm)
- use `-Zrustdoc-scrape-examples`
