### PR TITLE
Dump version (-> 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.4.0 - 2022-02-03
+
 ### Added
 
 - `ApiError::TooMuchInlineQueryResults` ([#135][pr135])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2018"
 
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <img src="https://img.shields.io/badge/license-MIT-blue.svg">
   </a>
   <a href="https://core.telegram.org/bots/api">
-    <img src="https://img.shields.io/badge/API%20coverage-Up%20to%205.6%20(inclusively)-green.svg">
+    <img src="https://img.shields.io/badge/API%20coverage-Up%20to%205.7%20(inclusively)-green.svg">
   </a>
   <a href="https://crates.io/crates/teloxide_core">
     <img src="https://img.shields.io/crates/v/teloxide_core.svg">
@@ -28,7 +28,7 @@
 </div>
 
 ```toml
-teloxide-core = "0.3"
+teloxide-core = "0.4"
 ```
 _Compiler support: requires rustc 1.49+_.
 


### PR DESCRIPTION
Finally, 60+ PRs later, new `teloxide-core` release!