### PR TITLE
Add a way for long-running requests to increase network timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+- `Payload::timeout_hint` method to properly handle long running requests like `GetUpdates` ([#180][pr180])
+
+[pr180]: https://github.com/teloxide/teloxide-core/pull/180
+
 ## 0.4.1 - 2022-02-13
 
 ### Fixed

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -214,6 +214,7 @@ impl Bot {
         let token = Arc::clone(&self.token);
         let api_url = Arc::clone(&self.api_url);
 
+        let timeout_hint = payload.timeout_hint();
         let params = serde_json::to_vec(payload)
             // this `expect` should be ok since we don't write request those may trigger error here
             .expect("serialization of request to be infallible");
@@ -226,6 +227,7 @@ impl Bot {
                 reqwest::Url::clone(&*api_url),
                 P::NAME,
                 params,
+                timeout_hint,
             )
             .await
         }
@@ -243,6 +245,7 @@ impl Bot {
         let token = Arc::clone(&self.token);
         let api_url = Arc::clone(&self.api_url);
 
+        let timeout_hint = payload.timeout_hint();
         let params = serde_multipart::to_form(payload);
 
         // async move to capture client&token&api_url&params
@@ -254,6 +257,7 @@ impl Bot {
                 reqwest::Url::clone(&*api_url),
                 P::NAME,
                 params,
+                timeout_hint,
             )
             .await
         }
@@ -271,6 +275,7 @@ impl Bot {
         let token = Arc::clone(&self.token);
         let api_url = self.api_url.clone();
 
+        let timeout_hint = payload.timeout_hint();
         let params = serde_multipart::to_form_ref(payload);
 
         // async move to capture client&token&api_url&params
@@ -282,6 +287,7 @@ impl Bot {
                 reqwest::Url::clone(&*api_url),
                 P::NAME,
                 params,
+                timeout_hint,
             )
             .await
         }

--- a/src/local_macros.rs
+++ b/src/local_macros.rs
@@ -100,6 +100,9 @@ macro_rules! impl_payload {
             @[multipart = $($multipart_attr:ident),*]
         )?
         $(
+            @[timeout_secs = $timeout_secs:ident]
+        )?
+        $(
             #[ $($method_meta:tt)* ]
         )*
         $vi:vis $Method:ident ($Setters:ident) => $Ret:ty {
@@ -179,6 +182,12 @@ macro_rules! impl_payload {
             type Output = $Ret;
 
             const NAME: &'static str = stringify!($Method);
+
+            $(
+                fn timeout_hint(&self) -> Option<std::time::Duration> {
+                    self.$timeout_secs.map(<_>::into).map(std::time::Duration::from_secs)
+                }
+            )?
         }
 
         calculated_doc! {

--- a/src/payloads/get_updates.rs
+++ b/src/payloads/get_updates.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use crate::types::{AllowedUpdate, Update};
 
 impl_payload! {
+    @[timeout_secs = timeout]
     /// Use this method to receive incoming updates using long polling ([wiki]). An Array of [`Update`] objects is returned.
     ///
     /// [wiki]: https://en.wikipedia.org/wiki/Push_technology#Long_polling

--- a/src/requests/payload.rs
+++ b/src/requests/payload.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /// Payload of a request.
 ///
 /// Simply speaking, structures implementing this trait represent arguments of
@@ -21,4 +23,12 @@ pub trait Payload {
     /// It is case insensitive, though must not include underscores. (e.g.
     /// `GetMe`, `GETME`, `getme`, `getMe` are ok, but `get_me` is not ok).
     const NAME: &'static str;
+
+    /// If this payload may take long time to execute (e.g. [`GetUpdates`] with
+    /// big `timeout`), the **minimum** timeout that should be used.
+    ///
+    /// [`GetUpdates`]: crate::payloads::GetUpdates
+    fn timeout_hint(&self) -> Option<Duration> {
+        None
+    }
 }


### PR DESCRIPTION
This allows
```rust
bot.get_updates().timeout(60).await?;
```
to succeed even with default client settings.