### PR TITLE
Deprecate `Message::chat_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Deprecated
+
+- `Message::chat_id` use `.chat.id` field instead ([#182][pr182])
+
+[pr182]: https://github.com/teloxide/teloxide-core/pull/182
+
 ### Fixed
 
 - Serialization of `SendPoll::type_` (it's now possible to send quiz polls) ([#181][pr181])

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -557,6 +557,7 @@ mod getters {
             }
         }
 
+        #[deprecated(since = "0.4.2", note = "use `.chat.id` field instead")]
         pub fn chat_id(&self) -> i64 {
             self.chat.id
         }


### PR DESCRIPTION
`.chat.id` is both shorted and doesn't require a function