### PR TITLE
Add missing enum variants to the `Update::chat()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- `Update::chat()` now returns `Some(&Chat)` for `UpdateKind::ChatMember`, `UpdateKind::MyChatMember`,
+  `UpdateKind::ChatJoinRequest` ([#184][pr184])
+
+[pr184]: https://github.com/teloxide/teloxide-core/pull/184
+
 ## 0.4.2 - 2022-02-17
 
 ### Deprecated

--- a/src/types/update.rs
+++ b/src/types/update.rs
@@ -50,6 +50,9 @@ impl Update {
             UpdateKind::ChannelPost(p) => Some(&p.chat),
             UpdateKind::EditedChannelPost(p) => Some(&p.chat),
             UpdateKind::CallbackQuery(q) => Some(&q.message.as_ref()?.chat),
+            UpdateKind::ChatMember(m) => Some(&m.chat),
+            UpdateKind::MyChatMember(m) => Some(&m.chat),
+            UpdateKind::ChatJoinRequest(c) => Some(&c.chat),
             _ => None,
         }
     }


### PR DESCRIPTION
Fixes teloxide/teloxide#528