### PR TITLE
Revert "better timeouts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Update::chat()` now returns `Some(&Chat)` for `UpdateKind::ChatMember`, `UpdateKind::MyChatMember`,
   `UpdateKind::ChatJoinRequest` ([#184][pr184])
+- `get_updates` timeouts (partially revert buggy [#180][pr180]) ([#185][pr185])
 
 [pr184]: https://github.com/teloxide/teloxide-core/pull/184
+[pr185]: https://github.com/teloxide/teloxide-core/pull/185
 
-## 0.4.2 - 2022-02-17
+## 0.4.2 - 2022-02-17 [yanked]
 
 ### Deprecated
 

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -16,7 +16,7 @@ pub async fn request_multipart<T>(
     api_url: reqwest::Url,
     method_name: &str,
     params: reqwest::multipart::Form,
-    timeout_hint: Option<Duration>,
+    _timeout_hint: Option<Duration>,
 ) -> ResponseResult<T>
 where
     T: DeserializeOwned,
@@ -40,9 +40,10 @@ where
         .build()
         .map_err(RequestError::Network)?;
 
-    if let Some(timeout) = timeout_hint {
-        *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
-    }
+    // FIXME: uncomment this, when reqwest starts setting default timeout early
+    // if let Some(timeout) = timeout_hint {
+    //     *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
+    // }
 
     let response = client
         .execute(request)
@@ -58,7 +59,7 @@ pub async fn request_json<T>(
     api_url: reqwest::Url,
     method_name: &str,
     params: Vec<u8>,
-    timeout_hint: Option<Duration>,
+    _timeout_hint: Option<Duration>,
 ) -> ResponseResult<T>
 where
     T: DeserializeOwned,
@@ -83,9 +84,10 @@ where
         .build()
         .map_err(RequestError::Network)?;
 
-    if let Some(timeout) = timeout_hint {
-        *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
-    }
+    // FIXME: uncomment this, when reqwest starts setting default timeout early
+    // if let Some(timeout) = timeout_hint {
+    //     *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
+    // }
 
     let response = client
         .execute(request)

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -34,7 +34,7 @@ where
     // [#460]: https://github.com/teloxide/teloxide/issues/460
     let method_name = method_name.trim_end_matches("Inline");
 
-    let mut request = client
+    let request = client
         .post(crate::net::method_url(api_url, token, method_name))
         .multipart(params)
         .build()
@@ -77,7 +77,7 @@ where
     // [#460]: https://github.com/teloxide/teloxide/issues/460
     let method_name = method_name.trim_end_matches("Inline");
 
-    let mut request = client
+    let request = client
         .post(crate::net::method_url(api_url, token, method_name))
         .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
         .body(params)

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -27,7 +27,7 @@ where
     // the used arguments we model this as `...` and `..._inline` pairs of methods.
     //
     // Currently inline versions have wrong Payload::NAME (ie with the "Inline"
-    // sufix). This removes the sufix allowing to call the right telegram method.
+    // suffix). This removes the suffix allowing to call the right telegram method.
     // Note that currently there are no normal telegram methods ending in "Inline",
     // so this is fine.
     //
@@ -70,7 +70,7 @@ where
     // the used arguments we model this as `...` and `..._inline` pairs of methods.
     //
     // Currently inline versions have wrong Payload::NAME (ie with the "Inline"
-    // sufix). This removes the sufix allowing to call the right telegram method.
+    // suffix). This removes the suffix allowing to call the right telegram method.
     // Note that currently there are no normal telegram methods ending in "Inline",
     // so this is fine.
     //


### PR DESCRIPTION
This PR partially reverts #180 that caused `get_updates` timeouts because instead of increasing timeout it set it, see https://github.com/teloxide/teloxide/issues/526.

To properly fix the issue we need https://github.com/seanmonstar/reqwest/pull/1477, but we shouldn't block other issues/features on it, so I've decided to partially revert #180 for the time being.