### PR TITLE
Add `HasPayload::with_payload_mut` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+- `HasPayload::with_payload_mut` function ([#189][pr189])
+
+[pr189]: https://github.com/teloxide/teloxide-core/pull/189
+
 ## 0.4.3 - 2022-03-08
 
 ### Added

--- a/src/requests/has_payload.rs
+++ b/src/requests/has_payload.rs
@@ -28,6 +28,16 @@ pub trait HasPayload {
 
     /// Gain immutable access to the underlying payload.
     fn payload_ref(&self) -> &Self::Payload;
+
+    /// Update payload with a function
+    fn with_payload_mut<F>(mut self, f: F) -> Self
+    where
+        Self: Sized,
+        F: FnOnce(&mut Self::Payload),
+    {
+        f(self.payload_mut());
+        self
+    }
 }
 
 impl<P> HasPayload for P


### PR DESCRIPTION
`HasPayload::with_payload_mut` allows to easily apply multiple changes to the payload without calling `payload_mut()` multiple times and creating temporary variable for the request. e.g.:
```rust
// without `with_payload_mut`
{
    let mut req = bot.set_webhook(url.clone());

    req.payload_mut().certificate = certificate.take();
    req.payload_mut().drop_pending_updates = drop_pending_updates;

    req.send().await?;
}

// with `with_payload_mut`
bot
    .set_webhook(url.clone())
    .with_payload_mut(|payload| {
        payload.certificate = certificate.take();
        payload.drop_pending_updates = drop_pending_updates;
    })
    .send()
    .await?
```
