### PR TITLE
Hide bot token in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.4.5 - 2022-04-03
+
+### Fixed
+
+- Hide bot token in errors ([#200][200])
+
+[200]: https://github.com/teloxide/teloxide-core/pull/200
+
 ## 0.4.4 - 2022-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2018"
 
 license = "MIT"

--- a/src/bot/download.rs
+++ b/src/bot/download.rs
@@ -41,6 +41,7 @@ impl<'w> Download<'w> for Bot {
             &self.token,
             path,
         )
+        .map(|res| res.map_err(crate::errors::hide_token))
         .boxed()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -758,11 +758,22 @@ pub(crate) fn hide_token(mut error: reqwest::Error) -> reqwest::Error {
         if let Some(token) = segment.and_then(|s| s.strip_prefix("bot")) {
             // make sure that what we are about to delete looks like a bot token
             if let Some((id, secret)) = token.split_once(':') {
-                if secret.len() >= 35
-                    && secret
-                        .chars()
-                        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-                    && id.chars().all(|c| c.is_ascii_digit())
+                // The part before the : in the token is the id of the bot.
+                let id_character = |c: char| c.is_ascii_digit();
+
+                // The part after the : in the token is the secret.
+                //
+                // In all bot tokens we could find the secret is 35 characters long and is
+                // 0-9a-zA-Z_- only.
+                //
+                // It would be nice to research if TBA always has 35 character secrets or if it
+                // is just a coincidence.
+                const SECRET_LENGTH: usize = 35;
+                let secret_character = |c: char| c.is_ascii_alphanumeric() || c == '-' || c == '_';
+
+                if secret.len() >= SECRET_LENGTH
+                    && id.chars().all(id_character)
+                    && secret.chars().all(secret_character)
                 {
                     // found token, hide only the token
                     let without_token =

--- a/src/net/request.rs
+++ b/src/net/request.rs
@@ -37,18 +37,14 @@ where
     let request = client
         .post(crate::net::method_url(api_url, token, method_name))
         .multipart(params)
-        .build()
-        .map_err(RequestError::Network)?;
+        .build()?;
 
     // FIXME: uncomment this, when reqwest starts setting default timeout early
     // if let Some(timeout) = timeout_hint {
     //     *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
     // }
 
-    let response = client
-        .execute(request)
-        .await
-        .map_err(RequestError::Network)?;
+    let response = client.execute(request).await?;
 
     process_response(response).await
 }
@@ -81,18 +77,14 @@ where
         .post(crate::net::method_url(api_url, token, method_name))
         .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
         .body(params)
-        .build()
-        .map_err(RequestError::Network)?;
+        .build()?;
 
     // FIXME: uncomment this, when reqwest starts setting default timeout early
     // if let Some(timeout) = timeout_hint {
     //     *request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;
     // }
 
-    let response = client
-        .execute(request)
-        .await
-        .map_err(RequestError::Network)?;
+    let response = client.execute(request).await?;
 
     process_response(response).await
 }
@@ -105,7 +97,7 @@ where
         tokio::time::sleep(DELAY_ON_SERVER_ERROR).await;
     }
 
-    let text = response.text().await.map_err(RequestError::Network)?;
+    let text = response.text().await?;
 
     serde_json::from_str::<TelegramResponse<T>>(&text)
         .map_err(|source| RequestError::InvalidJson {


### PR DESCRIPTION
This fixes a potential[^1] security vulnerability -- if bot shows errors from teloxide to the user & for some reason network error happened[^2] the url of the request would be included in the error. Since TBA includes bot token in the error this may lead to token leakage.

This PR fixes that issue by removing the token from the urls of `reqwest::Error`, we try to redact only the token, but if we fail we remove the whole url.

This can be tested by using a very low timeout value for the http reqwest client:
```rust
let client = reqwest::Client::builder()
    .timeout(std::time::Duration::from_millis(1))
    .build()
    .unwrap();

let bot = Bot::from_env_with_client(client).auto_send();

// see if the token is redacted when network error (timeout) happens
// while sending common requests
let _ = dbg!(bot.get_me().await);

// see if the token is redacted when network error (timeout) happens
// while downloading files ("path" is unimportant as the timeout is so
// low the request probably won't even be sent)
let _ = dbg!(bot.download_file_stream("path").next().await);
```

For me this gives the following result:
```text
[t.rs:26] bot.get_me().await = Err(
    Network(
        reqwest::Error {
            kind: Request,
            url: Url {
                scheme: "https",
                cannot_be_a_base: false,
                username: "",
                password: None,
                host: Some(
                    Domain(
                        "api.telegram.org",
                    ),
                ),
                port: None,
                path: "/token:redacted/GetMe",
                query: None,
                fragment: None,
            },
            source: TimedOut,
        },
    ),
)
[t.rs:31] bot.download_file_stream("path").next().await = Some(
    Err(
        reqwest::Error {
            kind: Request,
            url: Url {
                scheme: "https",
                cannot_be_a_base: false,
                username: "",
                password: None,
                host: Some(
                    Domain(
                        "api.telegram.org",
                    ),
                ),
                port: None,
                path: "/file/token:redacted/path",
                query: None,
                fragment: None,
            },
            source: TimedOut,
        },
    ),
)
```

Note that this branch is created from `v0.4.4` tag and not `master,` since the latter has breaking changes and we want to release this fix as `v0.4.5`. We'll need to make a release from this branch directly.

[^1]: Note that there are recorded cases where the token got exposed.
[^2]: Note that this can theoretically be controlled by the user when
      sending/downloading bigger files.
