### PR TITLE
Add `ChatId` and `UserId` to the prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Add `ChatId` and `UserId` to the prelude ([#212][pr212])
+
+[pr212]: https://github.com/teloxide/teloxide-core/pull/212
+
 ## 0.6.0 - 2022-04-25
 
 ### Added

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,5 +4,6 @@
 pub use crate::{
     payloads::setters::*,
     requests::{Request, Requester, RequesterExt},
+    types::{ChatId, UserId},
     Bot,
 };


### PR DESCRIPTION
I'm not entirely sure if we should do this, but this should simplify code that takes ids from external sources as integers.
I thought that that may be a good idea while working on the book.
This example currently needs an import of `ChatId`:
```rust
    // replace 0 with your user id
    let your_id = 0;
    bot.send_message(ChatId(your_id), "Hi!")
        // `.await` is needed to wait for an async operation
        // `?` propagates possible errors
        .await?;
```