### PR TITLE
Implement From for UserId and ChatId

### DIFF
--- a/src/types/chat_id.rs
+++ b/src/types/chat_id.rs
@@ -6,7 +6,7 @@ use crate::types::UserId;
 ///
 /// Note that "a chat" here means any of group, supergroup, channel or user PM.
 #[derive(Clone, Copy)]
-#[derive(Debug, derive_more::Display)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]

--- a/src/types/user_id.rs
+++ b/src/types/user_id.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Identifier of a user.
 #[derive(Clone, Copy)]
-#[derive(Debug, derive_more::Display)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]


### PR DESCRIPTION
With this change I can use something like this directly:

```rust
bla(42);
fn bla(id: ChatId) {…}
```

In order to make `bot.send_message(42, "")` work we would need a custom `impl From<i64> for Recipient` to allow this. But for `UserId` this would be an `impl From<u64> for Recipient`. Not sure how well this would work together.