### PR TITLE
Remove `log::warn!` from throttle implementation

### DIFF
--- a/src/adaptors/throttle/worker.rs
+++ b/src/adaptors/throttle/worker.rs
@@ -359,7 +359,8 @@ async fn freeze(
 
 async fn read_from_rx<T>(rx: &mut mpsc::Receiver<T>, queue: &mut Vec<T>, rx_is_closed: &mut bool) {
     if queue.is_empty() {
-        log::warn!("A-blocking on queue");
+        log::debug!("blocking on queue");
+
         match rx.recv().await {
             Some(req) => queue.push(req),
             None => *rx_is_closed = true,


### PR DESCRIPTION
"Blocking on queue" literally means "nothing is happening, waiting until something happens". There is no reason to warn users about that.
