### PR TITLE
Implement message entity parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [pr222]: https://github.com/teloxide/teloxide-core/pull/222
 
+### Added
+
+- Utilities to parse message entities (see `Message::parse_entities`) ([#217][pr217])
+
+[pr212]: https://github.com/teloxide/teloxide-core/pull/212
+
 ## 0.6.1 - 2022-06-02
 
 - Fix deserialization of `File` when `file_path` or `file_size` are missing ([#220][pr220])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ vecrem = { version = "0.1", optional = true }
 [dev-dependencies]
 pretty_env_logger = "0.4"
 tokio = { version = "1.8.0", features = ["fs", "macros"] }
+cool_asserts = "2.0.3"
 
 [features]
 default = ["native-tls"]

--- a/examples/erased.rs
+++ b/examples/erased.rs
@@ -6,9 +6,11 @@ use teloxide_core::{adaptors::trace, prelude::*, types::ChatAction};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
-    let chat_id = std::env::var("CHAT_ID")
-        .expect("Expected CHAT_ID env var")
-        .parse::<i64>()?;
+    let chat_id = ChatId(
+        std::env::var("CHAT_ID")
+            .expect("Expected CHAT_ID env var")
+            .parse::<i64>()?,
+    );
 
     let trace_settings = match std::env::var("TRACE").as_deref() {
         Ok("EVERYTHING_VERBOSE") => trace::Settings::TRACE_EVERYTHING_VERBOSE,

--- a/examples/self_info.rs
+++ b/examples/self_info.rs
@@ -7,9 +7,11 @@ use teloxide_core::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
-    let chat_id = std::env::var("CHAT_ID")
-        .expect("Expected CHAT_ID env var")
-        .parse::<i64>()?;
+    let chat_id = ChatId(
+        std::env::var("CHAT_ID")
+            .expect("Expected CHAT_ID env var")
+            .parse::<i64>()?,
+    );
 
     let bot = Bot::from_env()
         .parse_mode(ParseMode::MarkdownV2)

--- a/src/adaptors/throttle/settings.rs
+++ b/src/adaptors/throttle/settings.rs
@@ -19,6 +19,8 @@ type BoxedFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 /// // use settings in `Throttle::with_settings` or other constructors
 /// # let _ = settings;
 /// ```
+///
+/// [`Throttle`]: crate::adaptors::throttle::Throttle
 #[non_exhaustive]
 pub struct Settings {
     pub limits: Limits,
@@ -35,6 +37,7 @@ pub struct Settings {
 /// particular bot if it has a lot of users (but they may or may not do that).
 ///
 /// [@BotSupport]: https://t.me/botsupport
+/// [`Throttle`]: crate::adaptors::throttle::Throttle
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Limits {
     /// Allowed messages in one chat per second.

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::types::{
     Animation, Audio, BareChatId, Chat, ChatId, Contact, Dice, Document, Game,
     InlineKeyboardMarkup, Invoice, Location, MessageAutoDeleteTimerChanged, MessageEntity,
-    PassportData, PhotoSize, Poll, ProximityAlertTriggered, Sticker, SuccessfulPayment, True, User,
-    Venue, Video, VideoChatEnded, VideoChatParticipantsInvited, VideoChatScheduled,
-    VideoChatStarted, VideoNote, Voice, WebAppData,
+    MessageEntityRef, PassportData, PhotoSize, Poll, ProximityAlertTriggered, Sticker,
+    SuccessfulPayment, True, User, Venue, Video, VideoChatEnded, VideoChatParticipantsInvited,
+    VideoChatScheduled, VideoChatStarted, VideoNote, Voice, WebAppData,
 };
 
 /// This object represents a message.
@@ -1094,6 +1094,18 @@ impl Message {
         // The `url` produced by formatting is correct since username is
         // /[a-zA-Z0-9_]{5,32}/ and chat/message ids are integers.
         Some(reqwest::Url::parse(&url).unwrap())
+    }
+
+    pub fn parse_entities(&self) -> Option<Vec<MessageEntityRef<'_>>> {
+        self.text()
+            .zip(self.entities())
+            .map(|(t, e)| MessageEntityRef::parse(t, e))
+    }
+
+    pub fn parse_caption_entities(&self) -> Option<Vec<MessageEntityRef<'_>>> {
+        self.text()
+            .zip(self.entities())
+            .map(|(t, e)| MessageEntityRef::parse(t, e))
     }
 }
 

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -655,6 +655,18 @@ mod getters {
             }
         }
 
+        /// Returns message entities that represent text formatting.
+        ///
+        /// **Note:** you probably want to use [`parse_entities`] instead.
+        ///
+        /// This function returns `Some(entities)` for **text messages** and
+        /// `None` for all other kinds of messages (including photos with
+        /// captions).
+        ///
+        /// See also: [`caption_entities`].
+        ///
+        /// [`parse_entities`]: Message::parse_entities
+        /// [`caption_entities`]: Message::caption_entities
         pub fn entities(&self) -> Option<&[MessageEntity]> {
             match &self.kind {
                 Common(MessageCommon {
@@ -665,6 +677,18 @@ mod getters {
             }
         }
 
+        /// Returns message entities that represent text formatting.
+        ///
+        /// **Note:** you probably want to use [`parse_caption_entities`]
+        /// instead.
+        ///
+        /// This function returns `Some(entities)` for **media messages** and
+        /// `None` for all other kinds of messages (including text messages).
+        ///
+        /// See also: [`entities`].
+        ///
+        /// [`parse_caption_entities`]: Message::parse_caption_entities
+        /// [`entities`]: Message::entities
         pub fn caption_entities(&self) -> Option<&[MessageEntity]> {
             match &self.kind {
                 Common(MessageCommon {
@@ -1096,12 +1120,29 @@ impl Message {
         Some(reqwest::Url::parse(&url).unwrap())
     }
 
+    /// Returns message entities that represent text formatting.
+    ///
+    /// This function returns `Some(entities)` for **text messages** and
+    /// `None` for all other kinds of messages (including photos with
+    /// captions).
+    ///
+    /// See also: [`parse_caption_entities`].
+    ///
+    /// [`parse_caption_entities`]: Message::parse_caption_entities
     pub fn parse_entities(&self) -> Option<Vec<MessageEntityRef<'_>>> {
         self.text()
             .zip(self.entities())
             .map(|(t, e)| MessageEntityRef::parse(t, e))
     }
 
+    /// Returns message entities that represent text formatting.
+    ///
+    /// This function returns `Some(entities)` for **media messages** and
+    /// `None` for all other kinds of messages (including text messages).
+    ///
+    /// See also: [`parse_entities`].
+    ///
+    /// [`parse_entities`]: Message::parse_entities
     pub fn parse_caption_entities(&self) -> Option<Vec<MessageEntityRef<'_>>> {
         self.text()
             .zip(self.entities())

--- a/src/types/message_entity.rs
+++ b/src/types/message_entity.rs
@@ -195,6 +195,7 @@ impl<'a> MessageEntityRef<'a> {
     }
 
     /// Returns the length of this entity in bytes for UTF-8 encoding.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.range.len()
     }

--- a/src/types/message_entity.rs
+++ b/src/types/message_entity.rs
@@ -27,6 +27,14 @@ pub struct MessageEntity {
 /// mostly work with UTF-**8**. In order to use an entity we need to convert
 /// UTF-16 offsets to UTF-8 ones. This type represents a message entity with
 /// converted offsets and a reference to the text.
+///
+/// You can get [`MessageEntityRef`]s by calling [`parse_entities`] and
+/// [`parse_caption_entities`] methods of [`Message`] or by calling
+/// [`MessageEntityRef::parse`].
+///
+/// [`parse_entities`]: crate::types::Message::parse_entities
+/// [`parse_caption_entities`]: crate::types::Message::parse_caption_entities
+/// [`Message`]: crate::types::Message
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct MessageEntityRef<'a> {
     message: &'a str,
@@ -156,34 +164,47 @@ impl MessageEntity {
 }
 
 impl<'a> MessageEntityRef<'a> {
+    /// Returns kind of this entity.
     pub fn kind(&self) -> &'a MessageEntityKind {
         self.kind
     }
 
+    /// Returns the text that this entity is related to.
     pub fn text(&self) -> &'a str {
         &self.message[self.range.clone()]
     }
 
+    /// Returns range that this entity is related to.
+    ///
+    /// The range is in bytes for UTF-8 encoding i.e. you can use it with common
+    /// Rust strings.
     pub fn range(&self) -> Range<usize> {
         self.range.clone()
     }
 
+    /// Returns the offset (in bytes, for UTF-8) to the start of this entity in
+    /// the original message.
     pub fn start(&self) -> usize {
         self.range.start
     }
 
+    /// Returns the offset (in bytes, for UTF-8) to the end of this entity in
+    /// the original message.
     pub fn end(&self) -> usize {
         self.range.end
     }
 
+    /// Returns the length of this entity in bytes for UTF-8 encoding.
     pub fn len(&self) -> usize {
         self.range.len()
     }
 
+    /// Returns the full text of the original message.
     pub fn message_text(&self) -> &'a str {
         self.message
     }
 
+    /// Parses telegram [`MessageEntity`]s converting offsets to UTF-8.
     pub fn parse(text: &'a str, entities: &'a [MessageEntity]) -> Vec<Self> {
         // This creates entities with **wrong** offsets (UTF-16) that we later patch.
         let mut entities: Vec<_> = entities


### PR DESCRIPTION
This PR resolves the long standing issue of "how to use message entities if their offsets are in UTF-16 and Rust uses UTF-8".

I've also fixed a couple of issues with documentation and examples, I'll be sure to make CI check them too later =.=
