### PR TITLE
Fix is_channel assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Fix incorrect panic in `User::is_channel` ([#222][pr222])
+
+[pr222]: https://github.com/teloxide/teloxide-core/pull/222
+
 ## 0.6.1 - 2022-06-02
 
 - Fix deserialization of `File` when `file_path` or `file_size` are missing ([#220][pr220])

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -89,9 +89,9 @@ impl User {
         debug_assert!(
             !self.id.is_channel()
                 || (self.is_bot
-                    && self.first_name == "Group"
+                    && self.first_name == "Channel"
                     && self.last_name.is_none()
-                    && self.username.as_deref() == Some("GroupAnonymousBot"))
+                    && self.username.as_deref() == Some("Channel_Bot"))
         );
 
         self.id.is_channel()


### PR DESCRIPTION
Fix the following error:

```
thread 'tokio-runtime-worker' panicked at 'assertion failed: !self.id.is_channel() ||\n    (self.is_bot && self.first_name == \"Group\" && self.last_name.is_none() &&\n            self.username.as_deref() == Some(\"GroupAnonymousBot\"))', /home/kezi/.cargo/registry/src/github.com-1ecc6299db9ec823/teloxide-core-0.6.1/src/types/user.rs:89:9
```