### PR TITLE
Improve documentation of `file_size` fields

### DIFF
--- a/src/types/animation.rs
+++ b/src/types/animation.rs
@@ -37,7 +37,7 @@ pub struct Animation {
     #[serde(with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
-    /// A size of a file.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }
 

--- a/src/types/audio.rs
+++ b/src/types/audio.rs
@@ -34,7 +34,7 @@ pub struct Audio {
     #[serde(with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
-    /// A size of a file.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 
     /// A thumbnail of the album cover to which the music file belongs.

--- a/src/types/document.rs
+++ b/src/types/document.rs
@@ -32,6 +32,6 @@ pub struct Document {
     #[serde(default, with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
-    /// A size of a file.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }

--- a/src/types/file.rs
+++ b/src/types/file.rs
@@ -21,7 +21,7 @@ pub struct File {
     /// file.
     pub file_unique_id: String,
 
-    /// File size, if known.
+    /// File size in bytes, if known.
     ///
     /// **Note:** in the Telegram Bot API this field is optional, however it was
     /// errourneusly marked as required in Teloxide. To workaround this issue,

--- a/src/types/passport_file.rs
+++ b/src/types/passport_file.rs
@@ -17,8 +17,8 @@ pub struct PassportFile {
     /// file.
     pub file_unique_id: String,
 
-    /// File size.
-    pub file_size: u64,
+    /// File size in bytes.
+    pub file_size: u64, // FIXME: should be u32
 
     /// Time when the file was uploaded.
     #[serde(with = "crate::types::serde_date_from_unix_timestamp")]

--- a/src/types/photo_size.rs
+++ b/src/types/photo_size.rs
@@ -21,7 +21,7 @@ pub struct PhotoSize {
     /// Photo height.
     pub height: u32,
 
-    /// File size.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }
 

--- a/src/types/sticker.rs
+++ b/src/types/sticker.rs
@@ -44,6 +44,6 @@ pub struct Sticker {
     /// For mask stickers, the position where the mask should be placed.
     pub mask_position: Option<MaskPosition>,
 
-    /// File size.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -36,6 +36,6 @@ pub struct Video {
     #[serde(with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
-    /// File size.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }

--- a/src/types/video_note.rs
+++ b/src/types/video_note.rs
@@ -30,6 +30,6 @@ pub struct VideoNote {
     /// Video thumbnail.
     pub thumb: Option<PhotoSize>,
 
-    /// File size.
+    /// File size in bytes.
     pub file_size: Option<u32>,
 }

--- a/src/types/voice.rs
+++ b/src/types/voice.rs
@@ -22,6 +22,6 @@ pub struct Voice {
     #[serde(with = "crate::types::non_telegram_types::mime::opt_deser")]
     pub mime_type: Option<Mime>,
 
-    /// File size.
+    /// File size in bytes.
     pub file_size: Option<u64>,
 }


### PR DESCRIPTION
Previously it wasn't clear in which unit file size was provided.