### PR TITLE
`InlineKeyboardButton` cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+- `InlineKeyboardButton::{pay, login, web_app, callback_game, pay}` constructors ([#231][pr231])
+
+### Changed
+
+-  `InlineKeyboardButtonKind::Pay`'s only field now has type `True` ([#231][pr231])
+
+### Deprecated
+
+- `InlineKeyboardButton::{text, kind}` functions ([#231][pr231])
+
+[pr231]: https://github.com/teloxide/teloxide-core/pull/231
+
 ### Removed
 
 - `ChatPrivate::type_` field ([#232][pr232])

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -58,7 +58,7 @@ pub enum InlineKeyboardButtonKind {
     /// switched from, skipping the chat selection screen.
     ///
     /// [inline mode]: https://core.telegram.org/bots/inline
-    /// [switch_pm…]: https://core.telegram.org/bots/api#answerinlinequery
+    /// [switch_pm…]: crate::payloads::AnswerInlineQuery
     SwitchInlineQuery(String),
 
     /// If set, pressing the button will insert the bot‘s username and the

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -1,4 +1,4 @@
-use crate::types::{CallbackGame, LoginUrl, WebAppInfo};
+use crate::types::{CallbackGame, LoginUrl, True, WebAppInfo};
 use serde::{Deserialize, Serialize};
 
 /// This object represents one button of an inline keyboard.
@@ -110,8 +110,7 @@ pub enum InlineKeyboardButtonKind {
     /// row.
     ///
     /// [Pay button]: https://core.telegram.org/bots/api#payments
-    // FIXME(waffle): This should be using `True`
-    Pay(bool),
+    Pay(True),
 }
 
 /// Build buttons.

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -13,31 +13,6 @@ pub struct InlineKeyboardButton {
     pub kind: InlineKeyboardButtonKind,
 }
 
-impl InlineKeyboardButton {
-    pub fn new<S>(text: S, kind: InlineKeyboardButtonKind) -> Self
-    where
-        S: Into<String>,
-    {
-        Self {
-            text: text.into(),
-            kind,
-        }
-    }
-
-    pub fn text<S>(mut self, val: S) -> Self
-    where
-        S: Into<String>,
-    {
-        self.text = val.into();
-        self
-    }
-
-    pub fn kind(mut self, val: InlineKeyboardButtonKind) -> Self {
-        self.kind = val;
-        self
-    }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InlineKeyboardButtonKind {
@@ -113,16 +88,17 @@ pub enum InlineKeyboardButtonKind {
     Pay(True),
 }
 
-/// Build buttons.
-///
-/// # Examples
-/// ```
-/// use teloxide_core::types::InlineKeyboardButton;
-///
-/// let url = url::Url::parse("https://example.com").unwrap();
-/// let url_button = InlineKeyboardButton::url("Text".to_string(), url);
-/// ```
 impl InlineKeyboardButton {
+    pub fn new<S>(text: S, kind: InlineKeyboardButtonKind) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            text: text.into(),
+            kind,
+        }
+    }
+
     pub fn url<T>(text: T, url: reqwest::Url) -> InlineKeyboardButton
     where
         T: Into<String>,
@@ -130,6 +106,16 @@ impl InlineKeyboardButton {
         InlineKeyboardButton {
             text: text.into(),
             kind: InlineKeyboardButtonKind::Url(url),
+        }
+    }
+
+    pub fn login<T>(text: T, url: LoginUrl) -> InlineKeyboardButton
+    where
+        T: Into<String>,
+    {
+        InlineKeyboardButton {
+            text: text.into(),
+            kind: InlineKeyboardButtonKind::LoginUrl(url),
         }
     }
 
@@ -141,6 +127,16 @@ impl InlineKeyboardButton {
         InlineKeyboardButton {
             text: text.into(),
             kind: InlineKeyboardButtonKind::CallbackData(callback_data.into()),
+        }
+    }
+
+    pub fn web_app<T>(text: T, info: WebAppInfo) -> InlineKeyboardButton
+    where
+        T: Into<String>,
+    {
+        InlineKeyboardButton {
+            text: text.into(),
+            kind: InlineKeyboardButtonKind::WebApp(info),
         }
     }
 
@@ -169,5 +165,38 @@ impl InlineKeyboardButton {
                 switch_inline_query_current_chat.into(),
             ),
         }
+    }
+
+    pub fn callback_game<T>(text: T, game: CallbackGame) -> InlineKeyboardButton
+    where
+        T: Into<String>,
+    {
+        InlineKeyboardButton {
+            text: text.into(),
+            kind: InlineKeyboardButtonKind::CallbackGame(game),
+        }
+    }
+
+    pub fn pay<T>(text: T) -> InlineKeyboardButton
+    where
+        T: Into<String>,
+    {
+        InlineKeyboardButton {
+            text: text.into(),
+            kind: InlineKeyboardButtonKind::Pay(True),
+        }
+    }
+
+    pub fn text<S>(mut self, val: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.text = val.into();
+        self
+    }
+
+    pub fn kind(mut self, val: InlineKeyboardButtonKind) -> Self {
+        self.kind = val;
+        self
     }
 }

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -171,7 +171,13 @@ impl InlineKeyboardButton {
     {
         Self::new(text, InlineKeyboardButtonKind::Pay(True))
     }
+}
 
+impl InlineKeyboardButton {
+    #[deprecated(
+        since = "0.7.0",
+        note = "set correct text in the constructor or access the field directly"
+    )]
     pub fn text<S>(mut self, val: S) -> Self
     where
         S: Into<String>,
@@ -180,6 +186,10 @@ impl InlineKeyboardButton {
         self
     }
 
+    #[deprecated(
+        since = "0.7.0",
+        note = "set correct kind in the constructor or access the field directly"
+    )]
     pub fn kind(mut self, val: InlineKeyboardButtonKind) -> Self {
         self.kind = val;
         self

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -74,6 +74,7 @@ pub enum InlineKeyboardButtonKind {
     /// button.
     ///
     /// ## Note
+    ///
     /// This type of button **must** always be the first button in the first
     /// row.
     CallbackGame(CallbackGame),
@@ -81,6 +82,7 @@ pub enum InlineKeyboardButtonKind {
     /// Specify True, to send a [Pay button].
     ///
     /// ## Note
+    ///
     /// This type of button **must** always be the first button in the first
     /// row.
     ///
@@ -89,6 +91,7 @@ pub enum InlineKeyboardButtonKind {
 }
 
 impl InlineKeyboardButton {
+    /// Creates a new `InlineKeyboardButton`.
     pub fn new<S>(text: S, kind: InlineKeyboardButtonKind) -> Self
     where
         S: Into<String>,
@@ -99,6 +102,9 @@ impl InlineKeyboardButton {
         }
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`Url`] kind.
+    ///
+    /// [`Url`]: InlineKeyboardButtonKind::Url
     pub fn url<T>(text: T, url: reqwest::Url) -> Self
     where
         T: Into<String>,
@@ -106,6 +112,9 @@ impl InlineKeyboardButton {
         Self::new(text, InlineKeyboardButtonKind::Url(url))
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`LoginUrl`] kind.
+    ///
+    /// [`LoginUrl`]: InlineKeyboardButtonKind::LoginUrl
     pub fn login<T>(text: T, url: LoginUrl) -> Self
     where
         T: Into<String>,
@@ -113,6 +122,9 @@ impl InlineKeyboardButton {
         Self::new(text, InlineKeyboardButtonKind::LoginUrl(url))
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`CallbackData`] kind.
+    ///
+    /// [`CallbackData`]: InlineKeyboardButtonKind::CallbackData
     pub fn callback<T, C>(text: T, callback_data: C) -> Self
     where
         T: Into<String>,
@@ -124,6 +136,9 @@ impl InlineKeyboardButton {
         )
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`WebApp`] kind.
+    ///
+    /// [`WebApp`]: InlineKeyboardButtonKind::WebApp
     pub fn web_app<T>(text: T, info: WebAppInfo) -> Self
     where
         T: Into<String>,
@@ -131,6 +146,9 @@ impl InlineKeyboardButton {
         Self::new(text, InlineKeyboardButtonKind::WebApp(info))
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`SwitchInlineQuery`] kind.
+    ///
+    /// [`SwitchInlineQuery`]: InlineKeyboardButtonKind::SwitchInlineQuery
     pub fn switch_inline_query<T, Q>(text: T, switch_inline_query: Q) -> Self
     where
         T: Into<String>,
@@ -142,6 +160,10 @@ impl InlineKeyboardButton {
         )
     }
 
+    /// Constructor for `InlineKeyboardButton` with
+    /// [`SwitchInlineQueryCurrentChat`] kind.
+    ///
+    /// [`SwitchInlineQueryCurrentChat`]: InlineKeyboardButtonKind::SwitchInlineQueryCurrentChat
     pub fn switch_inline_query_current_chat<T, Q>(
         text: T,
         switch_inline_query_current_chat: Q,
@@ -158,6 +180,9 @@ impl InlineKeyboardButton {
         )
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`CallbackGame`] kind.
+    ///
+    /// [`CallbackGame`]: InlineKeyboardButtonKind::CallbackGame
     pub fn callback_game<T>(text: T, game: CallbackGame) -> Self
     where
         T: Into<String>,
@@ -165,6 +190,9 @@ impl InlineKeyboardButton {
         Self::new(text, InlineKeyboardButtonKind::CallbackGame(game))
     }
 
+    /// Constructor for `InlineKeyboardButton` with [`Pay`] kind.
+    ///
+    /// [`Pay`]: InlineKeyboardButtonKind::Pay
     pub fn pay<T>(text: T) -> Self
     where
         T: Into<String>,

--- a/src/types/inline_keyboard_button.rs
+++ b/src/types/inline_keyboard_button.rs
@@ -99,92 +99,77 @@ impl InlineKeyboardButton {
         }
     }
 
-    pub fn url<T>(text: T, url: reqwest::Url) -> InlineKeyboardButton
+    pub fn url<T>(text: T, url: reqwest::Url) -> Self
     where
         T: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::Url(url),
-        }
+        Self::new(text, InlineKeyboardButtonKind::Url(url))
     }
 
-    pub fn login<T>(text: T, url: LoginUrl) -> InlineKeyboardButton
+    pub fn login<T>(text: T, url: LoginUrl) -> Self
     where
         T: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::LoginUrl(url),
-        }
+        Self::new(text, InlineKeyboardButtonKind::LoginUrl(url))
     }
 
-    pub fn callback<T, C>(text: T, callback_data: C) -> InlineKeyboardButton
+    pub fn callback<T, C>(text: T, callback_data: C) -> Self
     where
         T: Into<String>,
         C: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::CallbackData(callback_data.into()),
-        }
+        Self::new(
+            text,
+            InlineKeyboardButtonKind::CallbackData(callback_data.into()),
+        )
     }
 
-    pub fn web_app<T>(text: T, info: WebAppInfo) -> InlineKeyboardButton
+    pub fn web_app<T>(text: T, info: WebAppInfo) -> Self
     where
         T: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::WebApp(info),
-        }
+        Self::new(text, InlineKeyboardButtonKind::WebApp(info))
     }
 
-    pub fn switch_inline_query<T, Q>(text: T, switch_inline_query: Q) -> InlineKeyboardButton
+    pub fn switch_inline_query<T, Q>(text: T, switch_inline_query: Q) -> Self
     where
         T: Into<String>,
         Q: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::SwitchInlineQuery(switch_inline_query.into()),
-        }
+        Self::new(
+            text,
+            InlineKeyboardButtonKind::SwitchInlineQuery(switch_inline_query.into()),
+        )
     }
 
     pub fn switch_inline_query_current_chat<T, Q>(
         text: T,
         switch_inline_query_current_chat: Q,
-    ) -> InlineKeyboardButton
+    ) -> Self
     where
         T: Into<String>,
         Q: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::SwitchInlineQueryCurrentChat(
+        Self::new(
+            text,
+            InlineKeyboardButtonKind::SwitchInlineQueryCurrentChat(
                 switch_inline_query_current_chat.into(),
             ),
-        }
+        )
     }
 
-    pub fn callback_game<T>(text: T, game: CallbackGame) -> InlineKeyboardButton
+    pub fn callback_game<T>(text: T, game: CallbackGame) -> Self
     where
         T: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::CallbackGame(game),
-        }
+        Self::new(text, InlineKeyboardButtonKind::CallbackGame(game))
     }
 
-    pub fn pay<T>(text: T) -> InlineKeyboardButton
+    pub fn pay<T>(text: T) -> Self
     where
         T: Into<String>,
     {
-        InlineKeyboardButton {
-            text: text.into(),
-            kind: InlineKeyboardButtonKind::Pay(True),
-        }
+        Self::new(text, InlineKeyboardButtonKind::Pay(True))
     }
 
     pub fn text<S>(mut self, val: S) -> Self


### PR DESCRIPTION
- Make `InlineKeyboardButtonKind::Pay.0` have type `True`
- Add more constructors to `InlineKeyboardButton`
- Make code in `inline_keyboard_button.rs` nicer
- Remove useless `InlineKeyboardButton::{text, kind}`
- Document `InlineKeyboardButton` constructors
- Update changelog
