### PR TITLE
Fix `Clone` implementation for `ErasedRequester`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+- `ErasedRequester<E>` now implements `Clone` even if `E` is not `Clone` ([#244][pr244])
+
+[pr244]: https://github.com/teloxide/teloxide-core/pull/244
+
 ### Added
 
 - `From<ApiError>`, `From<DownloadError>` and `From<std::io::Error>` impls for `RequestError` ([#241][pr241])

--- a/src/adaptors/erased.rs
+++ b/src/adaptors/erased.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 /// [`Requester`] with erased type.
-#[derive(Clone)]
 pub struct ErasedRequester<'a, E> {
     inner: Arc<dyn ErasableRequester<'a, Err = E> + 'a>,
 }
@@ -34,6 +33,15 @@ impl<'a, E> ErasedRequester<'a, E> {
 impl<E> std::fmt::Debug for ErasedRequester<'_, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("ErasedRequester").finish_non_exhaustive()
+    }
+}
+
+// NB. hand-written impl to avoid `E: Clone` bound
+impl<E> Clone for ErasedRequester<'_, E> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
     }
 }
 


### PR DESCRIPTION
`#[derive(Clone)]` added an unnecessary bound `E: Clone` that in practice made `ErasedRequester` not cloneable since `RequestError` doesn't implement `Clone`, this PR fixes that.