### PR TITLE
Fix parsing JSON error on get_sticker_set

### DIFF
--- a/src/types/sticker.rs
+++ b/src/types/sticker.rs
@@ -22,7 +22,7 @@ pub struct Sticker {
     /// The type of the sticker is independent from its format, 
     /// which is determined by the fields is_animated and is_video.
     #[serde(rename = "type")]
-    pub sticker_type: String,
+    pub sticker_type: StickerType,
 
     /// Sticker width.
     pub width: u16,
@@ -55,6 +55,18 @@ pub struct Sticker {
     /// File size in bytes.
     #[serde(default = "crate::types::file::file_size_fallback")]
     pub file_size: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum StickerType {
+    #[serde(rename = "regular")]
+    Regular,
+
+    #[serde(rename = "mask")]
+    Mask,
+
+    #[serde(rename = "custom_emoji")]
+    CustomEmoji,
 }
 
 /// Kind of a sticker - webp, animated or video.

--- a/src/types/sticker.rs
+++ b/src/types/sticker.rs
@@ -18,6 +18,12 @@ pub struct Sticker {
     /// file.
     pub file_unique_id: String,
 
+    /// Type of the sticker, currently one of “regular”, “mask”, “custom_emoji”. 
+    /// The type of the sticker is independent from its format, 
+    /// which is determined by the fields is_animated and is_video.
+    #[serde(rename = "type")]
+    pub sticker_type: String,
+
     /// Sticker width.
     pub width: u16,
 
@@ -42,6 +48,9 @@ pub struct Sticker {
 
     /// For mask stickers, the position where the mask should be placed.
     pub mask_position: Option<MaskPosition>,
+
+    /// For custom emoji stickers, unique identifier of the custom emoji
+    pub custom_emoji_id: Option<String>,
 
     /// File size in bytes.
     #[serde(default = "crate::types::file::file_size_fallback")]

--- a/src/types/sticker_set.rs
+++ b/src/types/sticker_set.rs
@@ -15,7 +15,11 @@ pub struct StickerSet {
     /// Sticker set title.
     pub title: String,
 
+    /// Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
+    pub sticker_type: String,
+
     /// Sticker kind shared by all stickers in this set.
+    #[serde(flatten)]
     pub kind: StickerKind,
 
     /// `true`, if the sticker set contains masks.

--- a/src/types/sticker_set.rs
+++ b/src/types/sticker_set.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{PhotoSize, Sticker, StickerKind};
+use crate::types::{PhotoSize, Sticker, StickerKind, StickerType};
 
 /// This object represents a sticker set.
 ///
@@ -16,7 +16,7 @@ pub struct StickerSet {
     pub title: String,
 
     /// Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
-    pub sticker_type: String,
+    pub sticker_type: StickerType,
 
     /// Sticker kind shared by all stickers in this set.
     #[serde(flatten)]


### PR DESCRIPTION
Getting error while trying to `get_sticker_set(sticker_set_name)`
```
An error while parsing JSON: data did not match any variant of untagged enum TelegramResponse
```


Looks like the types are not up-to-date
https://core.telegram.org/bots/api#stickerset
https://core.telegram.org/bots/api#sticker