### PR TITLE
Allow `.await`ing arbitrary requests!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,12 @@ env:
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
 
-  rust_nightly: nightly-2022-01-17
+  rust_nightly: nightly-2022-09-23
   # When updating this, also update:
   # - README.md
   # - src/lib.rs
   # - down below in a matrix  
-  rust_msrv: 1.58.0
-  # When updating this, also update:
-  # - down below in a matrix
-  #
-  # This is needed because some of our tests can't run on MSRV.
-  rust_msrv_dev: 1.59.0
+  rust_msrv: 1.64.0
 
   CI: 1
 
@@ -43,7 +38,6 @@ jobs:
       - check-examples
       - clippy
       - doc
-      - msrv
 
     steps:
       - run: exit 0
@@ -82,7 +76,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - msrv_dev
+          - msrv
     
         include:
           - rust: stable
@@ -92,10 +86,10 @@ jobs:
             toolchain: beta
             features: "--features full"
           - rust: nightly
-            toolchain: nightly-2022-01-17
+            toolchain: nightly-2022-09-23
             features: "--all-features"
-          - rust: msrv_dev
-            toolchain: 1.59.0
+          - rust: msrv
+            toolchain: 1.64.0
             features: "--features full"
 
     steps:      
@@ -194,27 +188,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: docs # from .cargo/config.toml
-
-  msrv:
-    name: minimal supported rust version
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Rust ${{ env.rust_msrv }}
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.rust_msrv }}
-          override: true
-
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
-
-      - name: Check 
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --verbose --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
+          components: rustfmt # required by codegen
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Changed
+
+- **You can now `.await` any `Request`!** ([#249][pr249])
+  - `Request` now requires `Self: IntoFuture`
+  - There is no need for `AutoSend` anymore
+- MSRV (Minimal Supported Rust Version) was bumped from `1.58.0` to `1.64.0`
+
 ### Removed
 
 - Methods for creating `InlineQuery` ([#246][pr244])
 
 [pr244]: https://github.com/teloxide/teloxide-core/pull/246
+
+### Deprecated
+
+- `AutoSend` adaptor ([#249][pr249])
+
+[pr249]: https://github.com/teloxide/teloxide-core/pull/249
 
 ## 0.7.1 - 2022-08-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 futures = "0.3.5"
 tokio = { version = "1.12.0", features = ["fs"] }
 tokio-util = { version = "0.7.0", features = ["codec"] }
-pin-project = "1.0.3"
+pin-project = "1.0.12"
 bytes = "1.0.0"
 reqwest = { version = "0.11.10", features = ["json", "stream", "multipart"], default-features = false }
 url = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [[example]]
 name = "self_info"
-required-features = ["tokio/macros", "tokio/rt-multi-thread", "auto_send"]
+required-features = ["tokio/macros", "tokio/rt-multi-thread"]
 
 [[example]]
 name = "erased"
-required-features = ["tokio/macros", "tokio/rt-multi-thread", "auto_send", "erased"]
+required-features = ["tokio/macros", "tokio/rt-multi-thread", "erased", "trace_adaptor"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ```toml
 teloxide-core = "0.7"
 ```
-_Compiler support: requires rustc 1.58+_.
+_Compiler support: requires rustc 1.64+_.
 
 [`teloxide`]: https://docs.rs/teloxide
 [Telegram Bot API]: https://core.telegram.org/bots/api

--- a/examples/erased.rs
+++ b/examples/erased.rs
@@ -32,9 +32,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Trace settings: {:?}", trace_settings);
 
     let bot = if trace_settings.is_empty() {
-        Bot::from_env().erase().auto_send()
+        Bot::from_env().erase()
     } else {
-        Bot::from_env().trace(trace_settings).erase().auto_send()
+        Bot::from_env().trace(trace_settings).erase()
     };
 
     bot.send_chat_action(chat_id, ChatAction::Typing).await?;

--- a/examples/self_info.rs
+++ b/examples/self_info.rs
@@ -14,8 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let bot = Bot::from_env()
-        .parse_mode(ParseMode::MarkdownV2)
-        .auto_send();
+        .parse_mode(ParseMode::MarkdownV2);
 
     let Me { user: me, .. } = bot.get_me().await?;
 

--- a/examples/self_info.rs
+++ b/examples/self_info.rs
@@ -13,8 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .parse::<i64>()?,
     );
 
-    let bot = Bot::from_env()
-        .parse_mode(ParseMode::MarkdownV2);
+    let bot = Bot::from_env().parse_mode(ParseMode::MarkdownV2);
 
     let Me { user: me, .. } = bot.get_me().await?;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-01-17"
+channel = "nightly-2022-09-23"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -14,6 +14,7 @@
 /// [`AutoSend`]: auto_send::AutoSend
 /// [`send`]: crate::requests::Request::send
 #[cfg(feature = "auto_send")]
+#[deprecated(since = "0.8.0", note = "`AutoSend` is no longer required to `.await` requests and is now noop")]
 pub mod auto_send;
 
 /// [`CacheMe`] bot adaptor which caches [`GetMe`] requests.
@@ -47,6 +48,7 @@ pub mod throttle;
 mod parse_mode;
 
 #[cfg(feature = "auto_send")]
+#[allow(deprecated)]
 pub use auto_send::AutoSend;
 #[cfg(feature = "cache_me")]
 pub use cache_me::CacheMe;

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -5,13 +5,16 @@
 //!
 //! [`Requester`]: crate::requests::Requester
 
-/// [`AutoSend`] bot adaptor which used to allow sending a request without calling
-/// [`send`].
+/// [`AutoSend`] bot adaptor which used to allow sending a request without
+/// calling [`send`].
 ///
 /// [`AutoSend`]: auto_send::AutoSend
 /// [`send`]: crate::requests::Request::send
 #[cfg(feature = "auto_send")]
-#[deprecated(since = "0.8.0", note = "`AutoSend` is no longer required to `.await` requests and is now noop")]
+#[deprecated(
+    since = "0.8.0",
+    note = "`AutoSend` is no longer required to `.await` requests and is now noop"
+)]
 pub mod auto_send;
 
 /// [`CacheMe`] bot adaptor which caches [`GetMe`] requests.

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -3,12 +3,9 @@
 //! Bot adaptors are very similar to the [`Iterator`] adaptors: they are bots
 //! wrapping other bots to alter existing or add new functionality.
 //!
-//! E.g. [`AutoSend`] allows `await`ing requests directly, no need to use
-//! `.send()`.
-//!
 //! [`Requester`]: crate::requests::Requester
 
-/// [`AutoSend`] bot adaptor which allows sending a request without calling
+/// [`AutoSend`] bot adaptor which used to allow sending a request without calling
 /// [`send`].
 ///
 /// [`AutoSend`]: auto_send::AutoSend

--- a/src/adaptors/auto_send.rs
+++ b/src/adaptors/auto_send.rs
@@ -7,32 +7,16 @@ use crate::{
     types::*,
 };
 
-/// Send requests automatically.
+/// Previously was used to send requests automatically.
 ///
-/// Requests returned by `<AutoSend<_> as `[`Requester`]`>` are [`Future`]s
-/// which means that you can simply `.await` them instead of using
-/// `.send().await`.
-///
-/// Notes:
-/// 1. This wrapper should be the most outer i.e.: `AutoSend<CacheMe<Bot>>`
-///    will automatically send requests, while `CacheMe<AutoSend<Bot>>` - won't.
-/// 2. After first call to `poll` on a request you will be unable to access
-///    payload nor could you use [`send_ref`](Request::send_ref).
-///
-/// ## Examples
-///
-/// ```rust
-/// use teloxide_core::{
-///     requests::{Requester, RequesterExt},
-///     types::Me,
-///     Bot,
-/// };
-///
-/// # async {
-/// let bot = Bot::new("TOKEN").auto_send();
-/// let myself: Me = bot.get_me().await?; // No .send()!
-/// # Ok::<_, teloxide_core::RequestError>(()) };
-/// ```
+/// Before addition of [`IntoFuture`] you could only `.await` [`Future`]s.
+/// This adaptor turned requests into futures, allowing to `.await` them,
+/// without calling `.send()`.
+/// 
+/// Now, however, all requests are required to implement `IntoFuture`, allowing
+/// you to `.await` them directly. This adaptor is noop, and shouldn't be used.
+/// 
+/// [`Future`]: std::future::Future
 #[derive(Clone, Debug)]
 pub struct AutoSend<B> {
     bot: B,

--- a/src/adaptors/auto_send.rs
+++ b/src/adaptors/auto_send.rs
@@ -12,10 +12,10 @@ use crate::{
 /// Before addition of [`IntoFuture`] you could only `.await` [`Future`]s.
 /// This adaptor turned requests into futures, allowing to `.await` them,
 /// without calling `.send()`.
-/// 
+///
 /// Now, however, all requests are required to implement `IntoFuture`, allowing
 /// you to `.await` them directly. This adaptor is noop, and shouldn't be used.
-/// 
+///
 /// [`Future`]: std::future::Future
 #[derive(Clone, Debug)]
 pub struct AutoSend<B> {

--- a/src/adaptors/cache_me.rs
+++ b/src/adaptors/cache_me.rs
@@ -1,4 +1,5 @@
 use std::{pin::Pin, sync::Arc};
+use std::future::IntoFuture;
 
 use futures::{
     future,
@@ -241,6 +242,15 @@ impl<R: Request<Payload = GetMe>> HasPayload for CachedMeRequest<R> {
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.1
+    }
+}
+
+impl<R: Request<Payload = GetMe>> IntoFuture for CachedMeRequest<R> {
+    type Output = Result<Me, R::Err>;
+    type IntoFuture = Send<R>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.send()
     }
 }
 

--- a/src/adaptors/cache_me.rs
+++ b/src/adaptors/cache_me.rs
@@ -1,5 +1,4 @@
-use std::{pin::Pin, sync::Arc};
-use std::future::IntoFuture;
+use std::{future::IntoFuture, pin::Pin, sync::Arc};
 
 use futures::{
     future,

--- a/src/adaptors/throttle/request.rs
+++ b/src/adaptors/throttle/request.rs
@@ -178,7 +178,7 @@ where
 
             let res = match &mut request {
                 ShareableRequest::Shared(shared) => shared.send_ref().await,
-                ShareableRequest::Owned(owned) => owned.take().unwrap().send().await,
+                ShareableRequest::Owned(owned) => owned.take().unwrap().await,
             };
 
             return res;
@@ -197,7 +197,7 @@ where
                 request.send_ref().await
             }
             (false, ShareableRequest::Shared(shared)) => shared.send_ref().await,
-            (false, ShareableRequest::Owned(owned)) => owned.take().unwrap().send().await,
+            (false, ShareableRequest::Owned(owned)) => owned.take().unwrap().await,
         };
 
         let retry_after = res.as_ref().err().and_then(<_>::retry_after);

--- a/src/adaptors/throttle/worker.rs
+++ b/src/adaptors/throttle/worker.rs
@@ -9,7 +9,7 @@ use vecrem::VecExt;
 use crate::{
     adaptors::throttle::{request_lock::RequestLock, ChatIdHash, Limits, Settings},
     errors::AsResponseParameters,
-    requests::{Request, Requester},
+    requests::Requester,
 };
 
 const MINUTE: Duration = Duration::from_secs(60);
@@ -321,7 +321,7 @@ async fn freeze(
                 // TODO: maybe not call `get_chat` every time?
 
                 // At this point there isn't much we can do with the error besides ignoring
-                if let Ok(chat) = bot.get_chat(id).send().await {
+                if let Ok(chat) = bot.get_chat(id).await {
                     match chat.slow_mode_delay() {
                         Some(delay) => {
                             let now = Instant::now();

--- a/src/adaptors/trace.rs
+++ b/src/adaptors/trace.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    future::Future,
+    future::{Future, IntoFuture},
     pin::Pin,
     task::{self, Poll},
 };
@@ -306,6 +306,21 @@ where
             trace_fn: self.trace_response_fn(),
             inner: self.inner.send_ref(),
         }
+    }
+}
+
+impl<R> IntoFuture for TraceRequest<R>
+where
+    R: Request,
+    Output<R>: Debug,
+    R::Err: Debug,
+    R::Payload: Debug,
+{
+    type Output = Result<Output<Self>, <Self as Request>::Err>;
+    type IntoFuture = <Self as Request>::Send;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.send()
     }
 }
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -29,7 +29,7 @@ const TELOXIDE_TOKEN: &str = "TELOXIDE_TOKEN";
 /// use teloxide_core::prelude::*;
 ///
 /// let bot = Bot::new("TOKEN");
-/// dbg!(bot.get_me().send().await?);
+/// dbg!(bot.get_me().await?);
 /// # Ok::<_, teloxide_core::RequestError>(()) };
 /// ```
 ///
@@ -158,7 +158,7 @@ impl Bot {
     /// let url = reqwest::Url::parse("https://localhost/tbas").unwrap();
     /// let bot = Bot::new("TOKEN").set_api_url(url);
     /// // From now all methods will use "https://localhost/tbas" as an API URL.
-    /// bot.get_me().send().await
+    /// bot.get_me().await
     /// # };
     /// ```
     ///

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -23,7 +23,7 @@ use xshell::{cmd, Shell};
 
 fn ensure_rustfmt(sh: &Shell) {
     // FIXME(waffle): find a better way to set toolchain
-    let toolchain = "nightly-2022-01-17";
+    let toolchain = "nightly-2022-09-23";
 
     let version = cmd!(sh, "rustup run {toolchain} rustfmt --version")
         .read()
@@ -38,7 +38,7 @@ fn ensure_rustfmt(sh: &Shell) {
 }
 
 pub fn reformat(text: String) -> String {
-    let toolchain = "nightly-2022-01-17";
+    let toolchain = "nightly-2022-09-23";
 
     let sh = Shell::new().unwrap();
     ensure_rustfmt(&sh);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!```toml
 //! teloxide_core = "0.7"
 //! ```
-//! _Compiler support: requires rustc 1.58+_.
+//! _Compiler support: requires rustc 1.64+_.
 //!
 //! ```
 //! # async {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! _Compiler support: requires rustc 1.58+_.
 //!
 //! ```
-//! # #[cfg(feature = "auto_send")]
 //! # async {
 //! # let chat_id = teloxide_core::types::ChatId(-1);
 //! use teloxide_core::{
@@ -20,7 +19,6 @@
 //!
 //! let bot = Bot::from_env()
 //!     .parse_mode(ParseMode::MarkdownV2)
-//!     .auto_send();
 //!
 //! let me = bot.get_me().await?;
 //!
@@ -46,7 +44,6 @@
 //! - `native-tls` = use [`native-tls`] tls implementation (**enabled by
 //!   default**)
 //! - `rustls` — use [`rustls`] tls implementation
-//! - `auto_send` — enables [`AutoSend`] bot adaptor
 //! - `trace_adaptor` — enables [`Trace`] bot adaptor
 //! - `erased` — enables [`ErasedRequester`] bot adaptor
 //! - `throttle` — enables [`Throttle`] bot adaptor
@@ -55,6 +52,7 @@
 //! - `nightly` — enables nightly-only features, currently:
 //!   - Removes some future boxing using `#![feature(type_alias_impl_trait)]`
 //!   - Used to built docs (`#![feature(doc_cfg, doc_notable_trait)]`)
+//! - `auto_send` — enables [`AutoSend`] bot adaptor (deprecated)
 //!
 //! [`AutoSend`]: adaptors::AutoSend
 //! [`Trace`]: adaptors::Trace

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,13 @@
 #![allow(clippy::return_self_not_must_use)]
 // Workaround for CI
 #![allow(rustdoc::bare_urls)]
+// FIXME: deal with these lints
+#![allow(
+    clippy::collapsible_str_replace,
+    clippy::borrow_deref_ref,
+    clippy::unnecessary_lazy_evaluations,
+    clippy::derive_partial_eq_without_eq
+)]
 
 // The internal helper macros.
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@
 //!     types::{DiceEmoji, ParseMode},
 //! };
 //!
-//! let bot = Bot::from_env()
-//!     .parse_mode(ParseMode::MarkdownV2);
+//! let bot = Bot::from_env().parse_mode(ParseMode::MarkdownV2);
 //!
 //! let me = bot.get_me().await?;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! };
 //!
 //! let bot = Bot::from_env()
-//!     .parse_mode(ParseMode::MarkdownV2)
+//!     .parse_mode(ParseMode::MarkdownV2);
 //!
 //! let me = bot.get_me().await?;
 //!

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -42,7 +42,7 @@ pub trait Download<'w>
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let bot = Bot::new("TOKEN");
     ///
-    /// let TgFile { file_path, .. } = bot.get_file("*file_id*").send().await?;
+    /// let TgFile { file_path, .. } = bot.get_file("*file_id*").await?;
     /// let mut file = File::create("/tmp/test.png").await?;
     /// bot.download_file(&file_path, &mut file).await?;
     /// # Ok(()) }

--- a/src/requests/json.rs
+++ b/src/requests/json.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -46,6 +48,20 @@ where
 
     fn send_ref(&self) -> Self::SendRef {
         SendRef::new(self)
+    }
+}
+
+impl<P> IntoFuture for JsonRequest<P>
+where
+    P: 'static,
+    P: Payload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    type Output = Result<P::Output, RequestError>;
+    type IntoFuture = <Self as Request>::Send;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.send()
     }
 }
 

--- a/src/requests/multipart.rs
+++ b/src/requests/multipart.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -47,6 +49,20 @@ where
 
     fn send_ref(&self) -> Self::SendRef {
         SendRef::new(self)
+    }
+}
+
+impl<P> IntoFuture for MultipartRequest<P>
+where
+    P: 'static,
+    P: Payload + MultipartPayload + Serialize,
+    P::Output: DeserializeOwned,
+{
+    type Output = Result<P::Output, RequestError>;
+    type IntoFuture = <Self as Request>::Send;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.send()
     }
 }
 

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -41,6 +41,7 @@ where
     /// Send this request.
     ///
     /// ## Examples
+    /// 
     /// ```
     /// # async {
     /// use teloxide_core::{
@@ -56,6 +57,11 @@ where
     /// let method = GetMe::new();
     /// let request = JsonRequest::new(bot, method);
     /// let _: Me = request.send().await.unwrap();
+    /// 
+    /// // You can also just await requests, without calling `send`:
+    /// let method = GetMe::new();
+    /// let request = JsonRequest::new(bot, method);
+    /// let _: Me = request.await.unwrap();
     /// # };
     /// ```
     #[must_use = "Futures are lazy and do nothing unless polled or awaited"]
@@ -72,6 +78,7 @@ where
     /// and then serializing it, this method should just serialize the data.)
     ///
     /// ## Examples
+    /// 
     /// ```
     /// # async {
     /// use teloxide_core::{prelude::*, requests::Request, types::ChatId, Bot};

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -41,7 +41,7 @@ where
     /// Send this request.
     ///
     /// ## Examples
-    /// 
+    ///
     /// ```
     /// # async {
     /// use teloxide_core::{
@@ -57,7 +57,7 @@ where
     /// let method = GetMe::new();
     /// let request = JsonRequest::new(bot, method);
     /// let _: Me = request.send().await.unwrap();
-    /// 
+    ///
     /// // You can also just await requests, without calling `send`:
     /// let method = GetMe::new();
     /// let request = JsonRequest::new(bot, method);
@@ -78,7 +78,7 @@ where
     /// and then serializing it, this method should just serialize the data.)
     ///
     /// ## Examples
-    /// 
+    ///
     /// ```
     /// # async {
     /// use teloxide_core::{prelude::*, requests::Request, types::ChatId, Bot};
@@ -105,7 +105,8 @@ where
     }
 }
 
-// FIXME: re-introduce `Either` impls once `Either: IntoFuture` (or make out own `Either`) (same for `Requester`)
+// FIXME: re-introduce `Either` impls once `Either: IntoFuture` (or make out own
+// `Either`) (same for `Requester`)
 
 // impl<L, R> Request for Either<L, R>
 // where

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -56,12 +56,11 @@ where
     /// // Note: it's recommended to `Requester` instead of creating requests directly
     /// let method = GetMe::new();
     /// let request = JsonRequest::new(bot, method);
+    /// let request_clone = request.clone();
     /// let _: Me = request.send().await.unwrap();
     ///
     /// // You can also just await requests, without calling `send`:
-    /// let method = GetMe::new();
-    /// let request = JsonRequest::new(bot, method);
-    /// let _: Me = request.await.unwrap();
+    /// let _: Me = request_clone.await.unwrap();
     /// # };
     /// ```
     #[must_use = "Futures are lazy and do nothing unless polled or awaited"]

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -32,8 +32,7 @@ use crate::{
 /// bot.send_message(chat_id, "<b>Text</b>")
 ///     // Optional parameters can be supplied by calling setters
 ///     .parse_mode(ParseMode::Html)
-///     // To send request to telegram you need to call `.send()` and await the resulting future
-///     .send()
+///     // To send request to telegram you need to `.await` the request
 ///     .await?;
 /// # Ok::<_, teloxide_core::RequestError>(())
 /// # };
@@ -51,7 +50,7 @@ use crate::{
 /// where
 ///     R: Requester,
 /// {
-///     bot.send_message(chat, "hi").send().await.expect("error")
+///     bot.send_message(chat, "hi").await.expect("error")
 /// }
 /// ```
 #[cfg_attr(all(any(docsrs, dep_docsrs), feature = "nightly"), doc(notable_trait))]

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -1090,30 +1090,30 @@ where
     forward_all! {}
 }
 
-macro_rules! fty_either {
-    ($T:ident) => {
-        either::Either<LR::$T, RR::$T>
-    };
-}
+// macro_rules! fty_either {
+//     ($T:ident) => {
+//         either::Either<LR::$T, RR::$T>
+//     };
+// }
 
-macro_rules! fwd_either {
-    ($m:ident $this:ident ($($arg:ident : $T:ty),*)) => {
-        match ($this) {
-            either::Either::Left(l) => either::Either::Left(l.$m($($arg),*)),
-            either::Either::Right(r) => either::Either::Right(r.$m($($arg),*)),
-        }
-    };
-}
+// macro_rules! fwd_either {
+//     ($m:ident $this:ident ($($arg:ident : $T:ty),*)) => {
+//         match ($this) {
+//             either::Either::Left(l) => either::Either::Left(l.$m($($arg),*)),
+//             either::Either::Right(r) =>
+// either::Either::Right(r.$m($($arg),*)),         }
+//     };
+// }
 
-impl<LR, RR> Requester for either::Either<LR, RR>
-where
-    LR: Requester,
-    RR: Requester<Err = LR::Err>,
-{
-    type Err = LR::Err;
+// impl<LR, RR> Requester for either::Either<LR, RR>
+// where
+//     LR: Requester,
+//     RR: Requester<Err = LR::Err>,
+// {
+//     type Err = LR::Err;
 
-    forward_all! { fwd_either, fty_either }
-}
+//     forward_all! { fwd_either, fty_either }
+// }
 
 #[test]
 fn codegen_requester_methods() {

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -29,7 +29,10 @@ pub trait RequesterExt: Requester {
 
     /// Send requests automatically, see [`AutoSend`] for more.
     #[cfg(feature = "auto_send")]
-    #[deprecated(since = "0.8.0", note = "`AutoSend` is no longer required to `.await` requests and is now noop")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "`AutoSend` is no longer required to `.await` requests and is now noop"
+    )]
     #[allow(deprecated)]
     fn auto_send(self) -> AutoSend<Self>
     where

--- a/src/requests/requester_ext.rs
+++ b/src/requests/requester_ext.rs
@@ -4,6 +4,7 @@ use crate::{adaptors::DefaultParseMode, requests::Requester, types::ParseMode};
 use crate::adaptors::CacheMe;
 
 #[cfg(feature = "auto_send")]
+#[allow(deprecated)]
 use crate::adaptors::AutoSend;
 
 #[cfg(feature = "erased")]
@@ -28,6 +29,8 @@ pub trait RequesterExt: Requester {
 
     /// Send requests automatically, see [`AutoSend`] for more.
     #[cfg(feature = "auto_send")]
+    #[deprecated(since = "0.8.0", note = "`AutoSend` is no longer required to `.await` requests and is now noop")]
+    #[allow(deprecated)]
     fn auto_send(self) -> AutoSend<Self>
     where
         Self: Sized,


### PR DESCRIPTION
As the title implies, this PR uses `IntoFuture` to allow `.await`ing any request. No need for `AutoSend`!