### PR TITLE
Fix how we set `rustdocflags` in the cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,5 +9,6 @@ docs = """doc
 --features=tokio/macros --features=tokio/rt-multi-thread
 """
 
+[build]
 # We pass "--cfg docsrs" when building docs to add `This is supported on feature="..." only.`
 rustdocflags = ["--cfg", "docsrs", "-Znormalize-docs"]


### PR DESCRIPTION
You love to see a config option silently ignored because you've misplaced it 🥲