### PR TITLE
Dump version `0.7.1` -> `0.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.8.0 - 2022-10-03
+
 ### Added 
 
 - Support for Telegram Bot API [version 6.2](https://core.telegram.org/bots/api#august-12-2022) ([#251][pr251])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "teloxide-core"
 description = "Core part of the `teloxide` library - telegram bot API client"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </div>
 
 ```toml
-teloxide-core = "0.7"
+teloxide-core = "0.8"
 ```
 _Compiler support: requires rustc 1.64+_.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! asynchronous and built using [`tokio`].
 //!
 //!```toml
-//! teloxide_core = "0.7"
+//! teloxide_core = "0.8"
 //! ```
 //! _Compiler support: requires rustc 1.64+_.
 //!


### PR DESCRIPTION
Now with TBA 6.2 supported and `.await` just working (tm) on requests!

While I'm not sure how fast can we finish work on the next release of `teloxide-macros` and `teloxide`, I don't think there are a lot of reasons to delay release of `teloxide-core`. We could stuff it with breaking changes forever, but we also need to draw the line somewhere.