### PR TITLE
Fix typos via typos-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.8.0 - 2022-10-03
 
-### Added 
+### Added
 
 - Support for Telegram Bot API [version 6.2](https://core.telegram.org/bots/api#august-12-2022) ([#251][pr251])
 
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [pr244]: https://github.com/teloxide/teloxide-core/pull/246
 
-### Fixed 
+### Fixed
 
 - `SetWebhook` request can now properly send certificate ([#250][pr250])
 - Serialization of `InputSticker::Webm` ([#252][pr252])
@@ -195,7 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `user.id` now uses `UserId` type, `ChatId` now represents only _chat id_, not channel username, all `chat_id` function parameters now accept `Recipient` [**BC**]
-- Improve `Throttling` adoptor ([#130][pr130])
+- Improve `Throttling` adaptor ([#130][pr130])
   - Freeze when getting `RetryAfter(_)` error
   - Retry requests that previously returned `RetryAfter(_)` error
 - `RequestError::RetryAfter` now has a `Duration` field instead of `i32`
@@ -476,7 +476,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor `ReplyMarkup` ([#pr65][pr65]) (**BC**)
   - Rename `ReplyMarkup::{InlineKeyboardMarkup => InlineKeyboard, ReplyKeyboardMarkup => Keyboard, ReplyKeyboardRemove => KeyboardRemove}`
-  - Add `inline_kb`, `keyboad`, `kb_remove` and `force_reply` `ReplyMarkup` consructors
+  - Add `inline_kb`, `keyboad`, `kb_remove` and `force_reply` `ReplyMarkup` constructors
   - Rename `ReplyKeyboardMarkup` => `KeyboardMarkup`
   - Rename `ReplyKeyboardRemove` => `KeyboardRemove`
   - Remove useless generic param from `ReplyKeyboardMarkup::new` and `InlineKeyboardMarkup::new`

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -164,7 +164,7 @@ impl Bot {
     ///
     /// ## Multi-instance behaviour
     ///
-    /// This method only sets the url for one bot instace, older clones are
+    /// This method only sets the url for one bot instance, older clones are
     /// unaffected.
     ///
     /// ```

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -109,7 +109,7 @@ pub fn ensure_files_contents<'a>(
     }
 
     let (s, were) = match err_count {
-        // No erros, everything is up to date
+        // No errors, everything is up to date
         0 => return,
         // Singular
         1 => ("", "was"),

--- a/src/requests/requester.rs
+++ b/src/requests/requester.rs
@@ -90,7 +90,7 @@ use crate::{
 /// let bot: DefaultParseMode<Bot> = Bot::new("TOKEN").parse_mode(ParseMode::Html);
 /// ```
 ///
-/// Because of this it's oftentimes more convinient to have a type alias:
+/// Because of this it's oftentimes more convenient to have a type alias:
 ///
 /// ```rust
 /// # async {

--- a/src/serde_multipart/error.rs
+++ b/src/serde_multipart/error.rs
@@ -41,7 +41,7 @@ impl From<Error> for RequestError {
         match err {
             Error::Io(ioerr) => RequestError::Io(ioerr),
 
-            // This should be ok since we (hopefuly) don't write request those may trigger errors
+            // This should be ok since we (hopefully) don't write request those may trigger errors
             // and `Error` is internal.
             e => unreachable!(
                 "we don't create requests those fail to serialize (if you see this, open an issue \

--- a/src/types/input_file.rs
+++ b/src/types/input_file.rs
@@ -241,7 +241,7 @@ impl InputFile {
     }
 }
 
-/// Adaptor for `AsyncRead` that allows clonning and converting to
+/// Adaptor for `AsyncRead` that allows cloning and converting to
 /// `multipart/form-data`
 #[derive(Clone)]
 struct Read {

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -292,7 +292,7 @@ pub enum MediaKind {
     // - `Animation` must be in front of `Document`
     //
     // This is needed so serde doesn't parse `Venue` as `Location` or `Animation` as `Document`
-    // (for backward compatability telegram duplicates some fields)
+    // (for backward compatibility telegram duplicates some fields)
     //
     // See <https://github.com/teloxide/teloxide/issues/481>
     Animation(MediaAnimation),


### PR DESCRIPTION
Automated by [typos-cli](https://crates.io/crates/typos-cli)

Also, I noticed there is a lingering Rust file in the repository, which isn't included anywhere as a rust module:

https://github.com/teloxide/teloxide-core/blob/6e9109b72881886b069f91712d00cdd5c59f3ffe/src/serde_multipart/unserializers.rs#L1-L113

I didn't study the project carefully yet to confirm it can be removed. However, it clearly uses a macro that isn't defined anywhere, so it is probably broken